### PR TITLE
[WIP] LLVM-based Locality Optimization for Chapel programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,10 @@ set(LLVM_LIBRARY_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/lib/${CMAKE_CFG_INT_DIR}")
 set(SOURCES
       llvmAggregateGlobalOps.cpp
       llvmGlobalToWide.cpp
+      llvmLocalityOptimization.cpp
       llvmUtil.cpp
+      ValueTable.cpp
+      IGraph.cpp
    )
 
 add_llvm_loadable_module( llvm-pgas ${SOURCES} )

--- a/IGraph.cpp
+++ b/IGraph.cpp
@@ -220,7 +220,6 @@ void IGraph::construct(Function *F, GlobalToWideInfo *info) {
 	    }		    
 	}
 	// Dominator Tree Computation
-
         // Dominator Frontier Computation
 	
 	// phi-insertion

--- a/IGraph.cpp
+++ b/IGraph.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//===----------------------------------------------------------------------===//
+// Chapel LLVM Locality Optimization by Akihiro Hayashi (ahayashi@rice.edu)
+//===----------------------------------------------------------------------===//
+// SSA Value Graph for Locality Inference
+//===----------------------------------------------------------------------===//
+
+#include "IGraph.h"
+
+#include <vector>
+#include <string>
+#include <fstream>
+
+using namespace std;
+using namespace llvm;
+
+unsigned int
+Node::getAddressSpace(Value* v)
+{
+    PointerType* pt = dyn_cast<PointerType>(v->getType());
+    if(pt) {
+	return pt->getAddressSpace();
+    } else {
+	return 0;
+    }
+}
+
+void
+Node::initLLMap()
+{
+    LLMap[value] = getAddressSpace(value);
+    // Instruction
+    Instruction *insn = dyn_cast<Instruction>(value);
+    if (!insn) return;
+    if (insn->getOpcode() != Instruction::Call) {
+	for(unsigned int i=0; i < insn->getNumOperands(); i++) {
+	    Value *op = insn->getOperand(i);
+	    LLMap[op] = getAddressSpace(op);
+	}
+    }
+    switch(insn->getOpcode()) {
+    case Instruction::Call: {
+	CallInst *call = cast<CallInst>(insn);
+	Function* f = call->getCalledFunction();
+	if (f != NULL) {
+	    /* *
+	     * We are assuming that gf.addr function calls correspond to Chapel's local statements, but this is not always true because gf.addr is also used to extract a local pointer from a wide pointer. We work on this later pass (see exemptionTest in llvmLocalityOptimization.cpp). 
+	     */  
+	    if (f->getName().startswith(".gf.addr")) {
+		// Argument of ".gf.addr" is definitely local
+		for (unsigned int i = 0; i < call->getNumArgOperands(); i++) {
+		    Value* v = call->getArgOperand(i);
+		    LLMap[v] = 0;
+		}
+ 	    }
+	}
+	break;
+    }
+    }    
+}

--- a/IGraph.cpp
+++ b/IGraph.cpp
@@ -57,6 +57,27 @@ Value* IGraph::getOperandIfLocalStmt(Instruction *insn) {
     return NULL;
 }
 
+void IGraph::setPostOrderNumberWithDFSImpl(Node *node, int &number) {
+    for (Node::iterator I = node->children_begin(),
+	                E = node->children_end();
+	 I != E; I++) {
+	Node *child = *I;
+	setPostOrderNumberWithDFSImpl(child, number);
+	if (child->getPostOrderNumber() == -1) {
+	    child->setPostOrderNumber(number++);
+	}
+    }
+
+}
+
+void IGraph::setPostOrderNumberWithDFS() {
+    Node *entry = this->getEntry();
+    entry->setPostOrderNumber(this->size() - 1);
+    int number = 0;
+    setPostOrderNumberWithDFSImpl(entry, number);
+    assert(this->size() - 1  == number);
+}
+
 void IGraph::construct(Function *F, GlobalToWideInfo *info) {
 
     if (debug) {
@@ -219,14 +240,163 @@ void IGraph::construct(Function *F, GlobalToWideInfo *info) {
 		}
 	    }		    
 	}
-	// Dominator Tree Computation
-        // Dominator Frontier Computation
-	
-	// phi-insertion
-	
-	// renaming
-	
-    }       
+    }
+    // Dominator Tree Computation
+    this->setPostOrderNumberWithDFS();
+    this->computeDominatorTree();
+    // Dominator Frontier Computation
+    this->computeDominanceFrontier();
+    // phi-insertion
+    
+    // renaming	
+
+}
+
+Node* IGraph::computeIntersect(Node* b1, Node* b2) {
+    Node *finger1 = b1;
+    Node *finger2 = b2;
+    while (finger1->getPostOrderNumber() != finger2->getPostOrderNumber()) {
+	while (finger1->getPostOrderNumber() < finger2->getPostOrderNumber()) {
+	    assert(finger1->getDom().count() == 1);
+	    finger1 = this->getNodeByPostOrderNumber(finger1->getDom().find_first());
+	}
+	while (finger2->getPostOrderNumber() < finger1->getPostOrderNumber()) {
+	    assert(finger2->getDom().count() == 1);
+	    finger2 = this->getNodeByPostOrderNumber(finger2->getDom().find_first());
+	}
+    }
+    return finger1;
+}
+
+void IGraph::computeDominatorTree() {
+    /* for all nodes, initialize the dominators array */
+#if 0
+    for (IGraph::iterator I = this->begin(), E = this->end(); I != E; I++) {
+	Node *n = *I;
+	DominatorTreeType t(this->size(), true);
+	n->setDom(t);
+    }
+    DominatorTreeType dom = entry->getDom();
+    dom.reset();
+    dom[entry->getPostOrderNumber()] = true;
+    entry->setDom(dom);
+    bool Changed = true;
+    while (Changed) {
+	Changed = false;
+	// reverse post order
+	for (int i = this->size() - 1; i >= 0; i--) {
+	    Node * p = this->getNodeByPostOrderNumber(i);
+	    if (p == this->getEntry()) continue;    
+	    Node::DominatorTreeType newSet(this->size(), true);
+	    for (Node::iterator IPRED = p->parents_begin(), EPRED = p->parents_end(); IPRED != EPRED; IPRED++) {
+		Node *nPred = *IPRED;
+		newSet &= nPred->getDom();
+	    }
+	    newSet[p->getPostOrderNumber()] = true;
+	    if (p->getDom() != newSet) {
+		p->setDom(newSet);
+		Changed = true;
+	    }
+	}
+    }
+#else
+    /* initialize the domiantor array */
+    for (IGraph::iterator I = this->begin(),
+	     E = this->end(); I != E; I++) {
+	Node *node = *I;
+	if (node == this->getEntry()) {
+	    Node::IDominatorTreeType init(this->size(), false);
+	    init[node->getPostOrderNumber()] = true;
+	    node->setDom(init);
+	    node->setUndefined(false);
+	} else {
+	    node->setUndefined(true);
+	}
+    }
+
+    bool Changed = true;
+    while (Changed) {
+	Changed = false;
+	/* in reverse postorder except entry node */
+	for (int i = this->size() - 1; i >= 0; i--) {
+	    Node * b = this->getNodeByPostOrderNumber(i);
+	    if (b == this->getEntry()) continue;
+	    /* pick one first processed predecessor  */
+	    Node::IDominatorTreeType new_idom(this->size(), false);
+	    Node *first_pred = NULL;
+	    for (IGraph::iterator IPRED = b->parents_begin(),
+		     EPRED = b->parents_end(); IPRED != EPRED; IPRED++) {
+		Node *node = *IPRED;
+		if (!node->getUndefined()) {
+		    first_pred = node;
+		    break;
+		}
+		
+	    }
+	    assert(first_pred != NULL);
+	    new_idom[first_pred->getPostOrderNumber()] = true;
+	    for (Node::iterator IPRED = b->parents_begin(),
+		     EPRED = b->parents_end(); IPRED != EPRED; IPRED++) {
+		Node *p = *IPRED;
+		if (p == first_pred) continue;
+		if (!p->getUndefined()) {
+		    new_idom.reset();
+		    int idx = computeIntersect(p, first_pred)->getPostOrderNumber();
+		    new_idom[idx] = true;
+		}
+	    }
+	    if (b->getDom() != new_idom) {
+		b->setDom(new_idom);
+		b->setUndefined(false);
+		Changed = true;
+	    }
+	}
+    }
+#endif
+    
+    for (IGraph::iterator I = this->begin(), E = this->end(); I != E; I++) {
+	Node *n = *I;
+	errs () << "IDOM(" << n->getPostOrderNumber() << ") : ";
+	Node::IDominatorTreeType b = n->getDom();
+	for (int i = 0; i < b.size(); i++) {
+	    if (b[i]) {
+		errs () << i << ", ";
+	    }
+	}
+	errs () << "\n";
+    }
+}
+
+void IGraph::computeDominanceFrontier() {
+    /* Reset Dominance Frontier */
+    for (IGraph::iterator I = this->begin(), E = this->end(); I != E; I++) {
+	Node *b = *I;
+	b->resetDominanceFrontier();
+    }
+    for (IGraph::iterator I = this->begin(), E = this->end(); I != E; I++) {
+	Node *b = *I;
+	if (b->getNumPreds() >= 2) {
+	    for (Node::iterator BI = b->parents_begin(),
+		     BE = b->parents_end(); BI != BE; BI++) {
+		Node *runner = *BI;
+		while (runner->getPostOrderNumber() != b->getDom().find_first()) {
+		    runner->addToDominanceFrontier(b);
+		    runner = this->getNodeByPostOrderNumber(runner->getDom().find_first());
+		} 
+	    }		 
+	}
+    }
+    for (IGraph::iterator I = this->begin(), E = this->end(); I != E; I++) {
+	Node *b = *I;
+	errs () << "DF(" << b->getPostOrderNumber() << ") : "; 
+	for (Node::df_iterator DI = b->df_begin(),
+		 DE = b->df_end(); DI != DE; DI++) {
+	    Node* df = *DI;
+	    errs () << df->getPostOrderNumber() << ", ";	    
+	}
+	errs () << "\n";
+    }
+
 }
 
 void IGraph::dumpDOT() {

--- a/IGraph.cpp
+++ b/IGraph.cpp
@@ -214,3 +214,27 @@ void IGraph::construct(Function *F, GlobalToWideInfo *info) {
 	
     }       
 }
+
+void IGraph::dumpDOT() {
+    std::string Filename = "ig." + this->getName().str() + ".dot";
+#if HAVE_LLVM_VER >= 35
+    std::error_code EC;
+    raw_fd_ostream File(Filename.c_str(), EC, sys::fs::F_Text);
+    
+    if (!EC) {
+	WriteGraph(File, (const IGraph*)this, false, "Habanero");
+    } else {
+	errs() << "Dump IGraph : error: "<< EC.message() << "\n";
+
+    }
+#else
+    std::string ErrorInfo;
+    raw_fd_ostream File(Filename.c_str(), ErrorInfo);
+    
+    if (ErrorInfo.empty()) {
+	WriteGraph(File, (const IGraph*)this, false, "Habanero");
+    } else {
+	errs() << "  error opening file for writing!";
+    }
+#endif    
+}       

--- a/IGraph.cpp
+++ b/IGraph.cpp
@@ -27,7 +27,7 @@
 #include <vector>
 #include <string>
 #include <fstream>
-
+#include <sstream>
 
 #if HAVE_LLVM_VER >= 35
 #include "llvm/IR/InstIterator.h"
@@ -71,6 +71,14 @@ void IGraph::setPostOrderNumberWithDFSImpl(Node *node, int &number) {
 }
 
 void IGraph::setPostOrderNumberWithDFS() {
+    /* 1. Reset Post order number */
+    for (IGraph::iterator I = this->begin(),
+	     E = this->end(); I != E; I++) {
+	Node *n = *I;
+	n->resetPostOrderNumber();
+    }
+
+    /* 2. set post order number recursively */
     Node *entry = this->getEntry();
     entry->setPostOrderNumber(this->size() - 1);
     int number = 0;
@@ -248,44 +256,81 @@ void IGraph::construct(Function *F, GlobalToWideInfo *info) {
     this->computeDominanceFrontier();
     // phi-insertion
     SmallVector<Node*, 128> phiAddedNodes; /* set of nodes where phi is added */
+    // For each addrspace(100) pointer
     for (SmallVector<Value*, 128>::iterator I = possiblyRemotePtrs.begin(),
 	     E = possiblyRemotePtrs.end(); I != E; I++) {
 	Value* val = *I;
-	SmallVector<Node*, 128> DEFNodes;
+	SmallVector<Node*, 128> DEFSites;
+	// Build a set of nodes that define the current addrspace(100) pointer
 	for (IGraph::iterator NI = this->begin(),
 		 NE = this->end(); NI != NE; NI++) {
 	    Node *node = *NI;
 	    if (node->getKind() == NODE_DEF && node->getValue() == val) {
-		DEFNodes.push_back(node);
+		DEFSites.push_back(node);
 	    }
 	}
-	while (!DEFNodes.empty()) {	    
-	    Node* DEFNode = DEFNodes[0];
-	    DEFNodes.erase(DEFNodes.begin());
+	// For each node that defines the current addrspace(100) pointer
+	while (!DEFSites.empty()) {
+	    Node* DEFNode = DEFSites[0];	    
+	    DEFSites.erase(DEFSites.begin());
+	    // For each dominance frontier of the current node
 	    for (Node::df_iterator DI = DEFNode->df_begin(),
 		     DE = DEFNode->df_end(); DI != DE; DI++) {
-		Node *DFofDEF = *DI;		
-		if (find(phiAddedNodes.begin(), phiAddedNodes.end(), DFofDEF) == phiAddedNodes.end()) {
-		    Node *phiNode = new Node(NODE_PHI, NULL, NULL, 0, 0);
+		Node *DFofDEF = *DI;
+		// skip if a phi-node is already inserted
+		if (find(phiAddedNodes.begin(),
+			 phiAddedNodes.end(),
+			 DFofDEF) == phiAddedNodes.end()) {
+		    Node *phiNode = new Node(NODE_PHI, val, NULL, 0, 0);
 		    this->addNode(phiNode);
+		    // inserting a new phi-node
+		    // preserve parents and children of DFofDEF first (TODO functionalize)
+		    Node::NodeElementType DFofDEFParents;
 		    for (Node::iterator NI = DFofDEF->parents_begin(),
 			     NE = DFofDEF->parents_end();
 			 NI != NE; NI++) {
 			Node *parents = *NI;
+			DFofDEFParents.push_back(parents);
+		    }
+		    for (Node::iterator NI = DFofDEFParents.begin(),
+			     NE = DFofDEFParents.end(); NI != NE; NI++) {
+			//
+			Node *parents = *NI;
+			DFofDEF->eraseFromParent(parents);
 			parents->eraseFromChild(DFofDEF);
 			parents->addChild(phiNode);
-		    }
-		    phiNode->addChild(DFofDEF);  
+			phiNode->addParents(parents);			
+		    }		   
+  		    DFofDEF->addParents(phiNode);
+		    phiNode->addChild(DFofDEF);
 		    phiAddedNodes.push_back(DFofDEF);
-		    if (find(DEFNodes.begin(), DEFNodes.end(), DFofDEF) == DEFNodes.end()) {
-			DEFNodes.push_back(DFofDEF);
+		    // phi-node is also DEF node
+		    if (find(DEFSites.begin(),
+			     DEFSites.end(), DFofDEF) == DEFSites.end()) {
+			DEFSites.push_back(DFofDEF);
 		    }
 		}
 	    }
 	}
     }
-    // renaming	
-
+    
+    // DT computation again 
+    // Dominator Tree Computation
+    if (phiAddedNodes.size() > 0) { 
+	this->setPostOrderNumberWithDFS();
+	this->computeDominatorTree();
+    }
+    
+    // renaming
+    // initilize counters and stacks
+    for (SmallVector<Value*, 128>::iterator I = possiblyRemotePtrs.begin(),
+	     E = possiblyRemotePtrs.end(); I != E; I++) {
+	Value* v = *I;
+	renamingCounters[v] = 0;
+	StackType st;
+	renamingStacks[v] = st;
+    }
+    this->performRenaming();
 }
 
 Node* IGraph::computeIntersect(Node* b1, Node* b2) {
@@ -325,6 +370,7 @@ void IGraph::computeDominatorTree() {
 	/* in reverse postorder except entry node */
 	for (int i = this->size() - 1; i >= 0; i--) {
 	    Node * b = this->getNodeByPostOrderNumber(i);
+	    errs () << "PostOrder(" << i << ")\n";
 	    if (b == this->getEntry()) continue;
 	    /* pick one first processed predecessor  */
 	    Node::IDominatorTreeType new_idom(this->size(), false);
@@ -372,11 +418,13 @@ void IGraph::computeDominatorTree() {
 }
 
 void IGraph::computeDominanceFrontier() {
-    /* Reset Dominance Frontier */
+    /* 1. Reset Dominance Frontier */
     for (IGraph::iterator I = this->begin(), E = this->end(); I != E; I++) {
 	Node *b = *I;
 	b->resetDominanceFrontier();
     }
+
+    /* 2. Compute Dominacne Frontier */
     for (IGraph::iterator I = this->begin(), E = this->end(); I != E; I++) {
 	Node *b = *I;
 	if (b->getNumPreds() >= 2) {
@@ -389,7 +437,9 @@ void IGraph::computeDominanceFrontier() {
 		} 
 	    }		 
 	}
-    }    
+    }
+
+    /* 3. Dump Dominance Frontier if needed */
     if (debug) {
 	for (IGraph::iterator I = this->begin(), E = this->end(); I != E; I++) {
 	    Node *b = *I;
@@ -405,8 +455,60 @@ void IGraph::computeDominanceFrontier() {
 
 }
 
+void IGraph::performRenamingImpl(Node *n, Node::NodeElementType &visited) {
+    // (TODO) see if previously visited
+    if (find(visited.begin(), visited.end(), n) != visited.end()) {
+	return;
+    } else {
+	visited.push_back(n);
+    }
+    
+    switch (n->getKind()) {
+    case NODE_PHI:
+	genName(n->getValue());
+	n->setVersion(renamingStacks[n->getValue()].top());
+	break;
+    case NODE_USE:
+	n->setVersion(renamingStacks[n->getValue()].top());
+	break;
+    case NODE_DEF:
+	genName(n->getValue());
+	n->setVersion(renamingStacks[n->getValue()].top());
+	break;
+    default:
+	; // do nothing
+    }
+    //
+    for (IGraph::iterator I = this->begin(), E = this->end(); I != E; I++) {
+	Node *node = *I;
+	// see if the node is a children of n in DT
+	if (n != node
+	    && n->getPostOrderNumber() == node->getDom().find_first()) {
+	    performRenamingImpl(node, visited);
+	}
+    }
+    if (n->getKind() == NODE_DEF) {
+	renamingStacks[n->getValue()].pop();
+    }
+}
+
+void IGraph::performRenaming() {
+    Node::NodeElementType visited;    
+    Node *entry = this->getEntry();    
+    performRenamingImpl(entry, visited);
+}
+
+void IGraph::genName(Value *v) {
+    int i = renamingCounters[v];
+    renamingStacks[v].push(i);
+    renamingCounters[v] = i + 1;    
+}
+
 void IGraph::dumpDOT() {
-    std::string Filename = "ig." + this->getName().str() + ".dot";
+    static int version = 0;
+    stringstream ss;
+    ss << version++;
+    std::string Filename = "ig." + this->getName().str() +ss.str() + ".dot";
 #if HAVE_LLVM_VER >= 35
     std::error_code EC;
     raw_fd_ostream File(Filename.c_str(), EC, sys::fs::F_Text);

--- a/IGraph.h
+++ b/IGraph.h
@@ -124,6 +124,7 @@ public:
 
     // Getter for general node information
     Value* getValue() const { return value; }
+    Instruction* getInstruction() const { return insn; }
     NodeKind getKind() const { return kind; }
     unsigned int getVersion() const { return version; }
     int getLocality() const { return locality; }
@@ -276,17 +277,6 @@ public:
     StringRef getName() const { return name; }
     unsigned size() const { return nodes.size(); }
 
-    Node* getNodeByValue(const Value* v) { 
-	for (NodeListType::iterator I = nodes.begin(),
-		 E = nodes.end(); I != E; I++) {
-	    Node* tmp = *I;
-	    if (v == tmp->getValue()) {
-		return tmp;
-	    }
-	}
-	return NULL;
-    }
-
     Node* getNodeByPostOrderNumber(const int number) { 
 	for (NodeListType::iterator I = nodes.begin(),
 		 E = nodes.end(); I != E; I++) {
@@ -299,7 +289,20 @@ public:
     }
 
     // Construct a inequality graph from an LLVM function
-    void construct(Function *F, GlobalToWideInfo *info);    
+    void construct(Function *F, GlobalToWideInfo *info);
+
+    //
+    Node* getDefNode(const Node*) const;
+    
+    enum Answer {
+	TRUE,
+	FALSE,
+	UNKNOWN	
+    };
+
+    //   
+    Answer prove(const Value*, const Instruction *, const int) const;
+    Answer proveUpward(const Node*, const int) const;
     
     // Used for dumping IGraph in DOT format
     void dumpDOT();

--- a/IGraph.h
+++ b/IGraph.h
@@ -33,8 +33,10 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvmUtil.h"
 #include "llvmGlobalToWide.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/GenericDomTree.h"
 #include "llvm/Support/GenericDomTreeConstruction.h"
+#include "llvm/Support/GraphWriter.h"
 
 #if HAVE_LLVM_VER >= 35
 #else
@@ -158,8 +160,8 @@ public:
     unsigned size() const { return nodes.size(); }
     void createGraphVizFile(const char* fileName);
 
-    // for GDB
-    void dump();
+    // for Debug
+    void dumpDOT();
 };
 
 namespace llvm {

--- a/IGraph.h
+++ b/IGraph.h
@@ -123,6 +123,14 @@ public:
 	}
     }
 
+    void eraseFromParent(Node* parent) {
+	iterator I = find(parents_begin(), parents_end(), parent);
+	if ( I != parents_end() ) {
+	    parents.erase(I);
+	    eraseFromChild(this);
+	}
+    }
+
     void addChild(Node *child) { 
 	iterator I = find(children_begin(), children_end(), child);
         if( I == children.end() ){
@@ -130,6 +138,15 @@ public:
 	    child->addParents(this);
 	}
     }
+
+    void eraseFromChild(Node* child) {
+	iterator I = find(children_begin(), children_end(), child);
+	if ( I != children_end() ) {
+	    children.erase(I);
+	    eraseFromParent(this);
+	}
+    }
+
 
     Value* getValue() const { return value; }
     NodeKind getKind() const { return kind; }
@@ -183,6 +200,8 @@ public:
 	    o << "_" << this->getVersion();
 	    break;
 	case NODE_PHI:
+	    o << "phi()";
+	    break;
 	case NODE_PI:
 	    break;
 	default:

--- a/IGraph.h
+++ b/IGraph.h
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//===----------------------------------------------------------------------===//
+// Chapel LLVM Locality Optimization by Akihiro Hayashi (ahayashi@rice.edu)
+//===----------------------------------------------------------------------===//
+// SSA Value Graph for Locality Inference
+//===----------------------------------------------------------------------===//
+
+#ifndef _IGRAPH_H_
+#define _IGRAPH_H_
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Support/DOTGraphTraits.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvmUtil.h"
+
+#if HAVE_LLVM_VER >= 35
+#else
+#include "llvm/Assembly/Writer.h"
+#endif
+
+#include <vector>
+#include <string>
+using namespace std;
+using namespace llvm;
+
+class Node {
+private:
+    StringRef name;
+    Value* value;
+    vector<Node*> children;
+    vector<Node*> parents;
+    DenseMap<Value*, unsigned> LLMap;
+    unsigned int getAddressSpace(Value *v);
+    void initLLMap();
+
+public:
+    Node(Value* _value) { value = _value; initLLMap(); };
+
+    // parents
+    vector<Node*>::iterator parents_begin() { return parents.begin(); }
+    vector<Node*>::iterator parents_end() { return parents.end(); }
+    // children
+    vector<Node*>::iterator begin() { return children.begin(); }
+    vector<Node*>::iterator end() { return children.end(); }
+    vector<Node*>::const_iterator begin() const { return children.begin(); }
+    vector<Node*>::const_iterator end() const { return children.end(); }
+
+    int getLL(Value* v) const {
+	int ll;
+	if (LLMap.find(v) != LLMap.end()) { 
+		ll = LLMap.find(v)->second;
+	} else {
+	    ll = -1;
+	}
+	return ll;
+    }
+    
+    void addParents(Node* parent) {
+	parents.push_back(parent);
+    }
+
+    void addChild(Node *child) { 
+	vector<Node*>::iterator I = find(children.begin(), children.end(), child);
+        if( I == children.end() ){
+	    children.push_back(child); 
+	    child->addParents(this);
+	}
+    }
+    
+    StringRef getName() const { return name; }
+    Value* getValue() const { return value; }
+
+};
+
+class IGraph {
+private:
+    StringRef name;
+    Node* entry;
+    vector<Node*> nodes;
+    vector<Node*> getRootNodes() { return nodes; }
+public:
+    IGraph (StringRef _name) { name = _name; }
+    Node* getEntry() const { return entry; }
+    StringRef getName() const { return name; }
+    
+    vector<Node*>::iterator begin() { return nodes.begin(); }
+    vector<Node*>::iterator end() { return nodes.end(); }
+    vector<Node*>::const_iterator begin() const { return nodes.begin(); }
+    vector<Node*>::const_iterator end() const { return nodes.end(); }
+
+    Node* getNodeByValue(const Value* v) { 
+	for (vector<Node*>::iterator I = nodes.begin(), E = nodes.end(); I != E; I++) {
+	    Node* tmp = *I;
+	    if (v == tmp->getValue()) {
+		return tmp;
+	    }
+	}
+	return NULL;
+    }
+    void addNode(Node* n) { nodes.push_back(n); } 
+
+    unsigned size() const { return nodes.size(); }
+    void createGraphVizFile(const char* fileName);
+
+    // for GDB
+    void dump();
+};
+
+namespace llvm {
+    template<> struct GraphTraits<Node*> {
+	typedef Node NodeType;
+	typedef std::vector<Node*>::iterator ChildIteratorType;
+	
+	static NodeType *getEntryNode(Node *node) { return node; }
+	static inline ChildIteratorType child_begin(NodeType *N) { return N->begin(); }
+	static inline ChildIteratorType child_end(NodeType *N) { return N->end(); }
+
+    };
+    template<> struct GraphTraits<const Node*> {
+	typedef const Node NodeType;
+	typedef vector<Node*>::const_iterator ChildIteratorType;
+	
+	static NodeType *getEntryNode(const Node *node) { return node; }
+	static inline ChildIteratorType child_begin(const NodeType *N) { return N->begin(); }
+	static inline ChildIteratorType child_end(const NodeType *N) { return N->end(); }
+
+    };
+
+    template<> struct GraphTraits<IGraph*> : public GraphTraits<Node*> {
+	static NodeType *getEntryNode(IGraph *G) { return G->getEntry(); }
+	typedef std::vector<Node*>::iterator nodes_iterator;
+
+	static nodes_iterator nodes_begin(IGraph *G) { return G->begin(); }
+	static nodes_iterator nodes_end(IGraph *G) { return G->end(); }
+	static unsigned nodes_size(IGraph *G) { return G->size(); }
+    };
+
+    template<> struct GraphTraits<const IGraph*> : public GraphTraits<const Node*> {
+	static NodeType *getEntryNode(const IGraph *G) { return G->getEntry(); }
+	typedef vector<Node*>::const_iterator nodes_iterator;
+
+	static nodes_iterator nodes_begin(const IGraph *G) { return G->begin(); }
+	static nodes_iterator nodes_end(const IGraph *G) { return G->end(); }
+	static unsigned nodes_size(const IGraph *G) { return G->size(); }
+    };
+    
+    template<> struct DOTGraphTraits<const IGraph*> : public DefaultDOTGraphTraits {
+	DOTGraphTraits (bool isSimple=false) : DefaultDOTGraphTraits(isSimple) {}
+
+	static std::string getGraphName(const IGraph* G) {
+	    return "Inequality Graph for '" + G->getName().str();
+	}
+
+	static std::string getSimpleNodeLabel(const Node* node,
+					      const IGraph *) {
+	    if (!node->getName().empty())
+		return node->getName().str();
+
+	    std::string Str;
+	    raw_string_ostream OS(Str);
+	    const Value *value = node->getValue();
+#if HAVE_LLVM_VER >= 35
+	    OS << value->getName();
+#else	    
+	    WriteAsOperand(OS, value, false);
+#endif	    
+	    OS << "FIXME";
+	    return OS.str();
+	}
+
+	static std::string getCompleteNodeLabel(const Node *node, 
+						const IGraph *) {
+	    std::string Str;
+	    raw_string_ostream OS(Str);
+	    if (node->getName().empty()) {
+#if HAVE_LLVM_VER >= 35 		    
+		OS << node->getValue()->getName();
+#else
+		WriteAsOperand(OS, node->getValue(), false);
+#endif		    
+		OS << ", LL(";
+#if HAVE_LLVM_VER >= 35 		    
+		OS << node->getValue()->getName();
+#else
+		WriteAsOperand(OS, node->getValue(), false);
+#endif		    
+		OS << ") = " << node->getLL(node->getValue()) << " : ";
+	    }
+	    OS << *node->getValue(); 
+	    OS << " ";
+	    Instruction *insn = dyn_cast<Instruction>(node->getValue());
+	    if (insn) {
+		for(unsigned int i=0; i < insn->getNumOperands(); i++) {
+		    Value *op = insn->getOperand(i);
+		    OS << ", LL(";
+#if HAVE_LLVM_VER >= 35 		    
+		    OS << op->getName();
+#else
+		    WriteAsOperand(OS, op, false);
+#endif		    
+		    OS << ") = " << node->getLL(op);
+		}
+	    }
+	    std::string OutStr = OS.str();
+	    if (OutStr[0] == '\n') OutStr.erase(OutStr.begin());
+
+	    // Process string output to make it nicer...
+	    for (unsigned i = 0; i != OutStr.length(); ++i) {
+		if (OutStr[i] == '\n') {                            // Left justify
+		    OutStr[i] = '\\';
+		    OutStr.insert(OutStr.begin()+i+1, 'l');
+		} else if (OutStr[i] == ';') {                      // Delete comments!
+		    unsigned Idx = OutStr.find('\n', i+1);            // Find end of line
+		    OutStr.erase(OutStr.begin()+i, OutStr.begin()+Idx);
+		    --i;
+		}
+	    }
+	    return OutStr;
+	}
+
+	std::string getNodeLabel(const Node *node,
+				 const IGraph *graph) {
+	    if (isSimple())
+		return getSimpleNodeLabel(node, graph);
+	    else
+		return getCompleteNodeLabel(node, graph);
+	}
+
+	static std::string getEdgeSourceLabel(const Node *node,
+					      vector<Node*>::const_iterator I) {
+#if 0
+	    // Label source of conditional branches with "T" or "F"
+	    if (const BranchInst *BI = dyn_cast<BranchInst>(Node->getTerminator()))
+		if (BI->isConditional())
+		    return (I == succ_begin(Node)) ? "T" : "F";
+    
+	    // Label source of switch edges with the associated value.
+	    if (const SwitchInst *SI = dyn_cast<SwitchInst>(Node->getTerminator())) {
+		unsigned SuccNo = I.getSuccessorIndex();
+
+		if (SuccNo == 0) return "def";
+      
+		std::string Str;
+		raw_string_ostream OS(Str);
+		SwitchInst::ConstCaseIt Case =
+		    SwitchInst::ConstCaseIt::fromSuccessorIndex(SI, SuccNo); 
+		OS << Case.getCaseValue()->getValue();
+		return OS.str();
+	    }    
+#endif
+	    return "";
+	}
+    };
+}
+
+#endif // _IGRAPH_H_

--- a/IGraph.h
+++ b/IGraph.h
@@ -172,7 +172,8 @@ public:
 
     // Used for visiting nodes in post order
     void resetPostOrderNumber() { postOrderNumber = -1; };
-    void setPostOrderNumber(int _postOrderNumber) { postOrderNumber = _postOrderNumber; }
+    void setPostOrderNumber(int _postOrderNumber) {
+	postOrderNumber = _postOrderNumber; }
     int getPostOrderNumber() const { return postOrderNumber; }
     // Used for calculating dominator tree
     bool getUndefined() { return domIsUndefined; }
@@ -186,7 +187,8 @@ public:
 	
     /* === Utility functions for Inequality Graph Construction Ends === */
 
-    // Used for showing information on this node (e.g. when dumping in DOT format) 
+    // Used for showing information on this node
+    // (e.g. when dumping in DOT format) 
     void printAsOperand(raw_ostream&, bool) const;
     
     // Used for debug
@@ -216,7 +218,8 @@ private:
     PossiblyRemoteArrayType possiblyRemoteArgs;
 
     // Used for analyzing def/use of locality
-    typedef DenseMap<Instruction*, std::tuple<Node::NodeKind, Value*, Instruction*, int>> InsnToNodeMapType;
+    typedef DenseMap<Instruction*, std::tuple<Node::NodeKind, Value*, 
+Instruction*, int>> InsnToNodeMapType;
 
     // For Renaming
     typedef std::stack<int> StackType;
@@ -319,23 +322,36 @@ namespace llvm {
 	typedef NodeType::const_iterator ChildIteratorType;
 	
 	static NodeType *getEntryNode(const Node *node) { return node; }
-	static inline ChildIteratorType child_begin(const NodeType *N) { return N->children_begin(); }
-	static inline ChildIteratorType child_end(const NodeType *N) { return N->children_end(); }
+	static inline ChildIteratorType child_begin(const NodeType *N) {
+	    return N->children_begin();
+	}
+	static inline ChildIteratorType child_end(const NodeType *N) {
+	    return N->children_end();
+	}
     };
     
     // template specialization for <const IGraph*>
-    template<> struct GraphTraits<const IGraph*> : public GraphTraits<const Node*> {
-	static NodeType *getEntryNode(const IGraph *G) { return G->getEntry(); }
+    template<> struct GraphTraits<const IGraph*> :
+	public GraphTraits<const Node*> {
+	static NodeType *getEntryNode(const IGraph *G) {
+	    return G->getEntry();
+	}
 	typedef IGraph::const_iterator nodes_iterator;
 
-	static nodes_iterator nodes_begin(const IGraph *G) { return G->begin(); }
-	static nodes_iterator nodes_end(const IGraph *G) { return G->end(); }
+	static nodes_iterator nodes_begin(const IGraph *G) {
+	    return G->begin();
+	}
+	static nodes_iterator nodes_end(const IGraph *G) {
+	    return G->end();
+	}
 	static unsigned size(const IGraph *G) { return G->size(); }
     };
     
     // template specialization for <const IGraph*> for Writing DOTGraph
-    template<> struct DOTGraphTraits<const IGraph*> : public DefaultDOTGraphTraits {
-	DOTGraphTraits (bool isSimple=false) : DefaultDOTGraphTraits(isSimple) {}
+    template<> struct DOTGraphTraits<const IGraph*> : public 
+	DefaultDOTGraphTraits {
+	DOTGraphTraits (bool isSimple=false) : DefaultDOTGraphTraits(isSimple) 
+	{}
 
 	static std::string getGraphName(const IGraph* G) {
 	    return "Inequality Graph for '" + G->getName().str();

--- a/IGraph.h
+++ b/IGraph.h
@@ -50,6 +50,7 @@ using namespace llvm;
 
 
 enum NodeKind {
+    NODE_ENTRY,
     NODE_DEF,
     NODE_USE,
     NODE_PHI,
@@ -75,7 +76,6 @@ public:
 	insn = _insn;
 	version = _version;
 	locality = _locality;
-	
     };
 
     // parents
@@ -124,10 +124,8 @@ public:
 class IGraph {
 private:
     StringRef name;
-    // required?
     Node* entry;    
     vector<Node*> nodes;
-    // required?
     vector<Node*> getRootNodes() { return nodes; }
     Value* getOperandIfLocalStmt(Instruction *insn);
 
@@ -140,7 +138,8 @@ public:
     
     Node* getEntry() const { return entry; }
     StringRef getName() const { return name; }
-    
+
+    // Iterator for enumerating nodes of IGraph.
     vector<Node*>::iterator begin() { return nodes.begin(); }
     vector<Node*>::iterator end() { return nodes.end(); }
     vector<Node*>::const_iterator begin() const { return nodes.begin(); }
@@ -155,10 +154,10 @@ public:
 	}
 	return NULL;
     }
+
     void addNode(Node* n) { nodes.push_back(n); } 
 
     unsigned size() const { return nodes.size(); }
-    void createGraphVizFile(const char* fileName);
 
     // for Debug
     void dumpDOT();
@@ -185,7 +184,6 @@ namespace llvm {
     // static unsigned       size       (GraphType *G)
     //    Return total number of nodes in the graph
 
-    
     // template specialization for <Node*>
     template<> struct GraphTraits<Node*> {
 	typedef Node NodeType;
@@ -227,7 +225,7 @@ namespace llvm {
     };
     
 
-    // template specialization for <const IGraph*> for Write Graph
+    // template specialization for <const IGraph*> for Writing DOTGraph
     template<> struct DOTGraphTraits<const IGraph*> : public DefaultDOTGraphTraits {
 	DOTGraphTraits (bool isSimple=false) : DefaultDOTGraphTraits(isSimple) {}
 
@@ -260,6 +258,9 @@ namespace llvm {
 	    	    
 	    // print Node Information
 	    switch (node->getKind()) {
+	    case NODE_ENTRY:
+		OS << "entry";
+		break;
 	    case NODE_DEF:
 #if HAVE_LLVM_VER >= 35
 	    value->printAsOperand(OS, false);

--- a/IGraph.h
+++ b/IGraph.h
@@ -232,7 +232,7 @@ private:
     void addNode(Node* n) { nodes.push_back(n); }
 
     // Language specific 
-    Value* getOperandIfLocalStmt(Instruction *insn);
+    std::pair<bool, Value*> isChapelLocalStmt(Instruction *insn);
 
     // For Initial IGraph construction from LLVM Function
     InsnToNodeMapType analyzeDefUseOfLocality(Function *, GlobalToWideInfo *);

--- a/IGraph.h
+++ b/IGraph.h
@@ -240,14 +240,14 @@ private:
 
     // For constructing Locality-SSA in IGraph
     void calculateDTandDF();
-    void setPostOrderNumberWithDFSImpl(Node*, int&);
+    void setPostOrderNumberWithDFSInternal(Node*, int&, Node::NodeElementType&);
     void setPostOrderNumberWithDFS();
     void computeDominatorTree();
     Node* computeIntersect(Node*, Node*);
     void computeDominanceFrontier();   
     void performPhiNodeInsertion(bool&);
     void performRenaming();
-    void performRenamingImpl(Node *, Node::NodeElementType&);
+    void performRenamingInternal(Node *, Node::NodeElementType&);
     void generateName(Value *v);
 
     /* === Utility functions for Inequality graph construction Ends === */

--- a/ValueTable.cpp
+++ b/ValueTable.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//===----------------------------------------------------------------------===//
+// Chapel LLVM Locality Optimization by Akihiro Hayashi (ahayashi@rice.edu)
+//===----------------------------------------------------------------------===//
+// This is a reduced version of the original LLVM global value numbering pass. (GVN.cpp)
+// This pass is only used for assigning a value number to variables and expressions and 
+// does not perform any CSE (common subexpression elimination)
+//===----------------------------------------------------------------------===//
+
+#include "ValueTable.h"
+#include "llvmGlobalToWide.h"
+
+Expression ValueTable::create_expression(Instruction *I) {
+    Expression e;
+    e.type = I->getType();
+    e.opcode = I->getOpcode();
+    for (Instruction::op_iterator OI = I->op_begin(), OE = I->op_end();
+	 OI != OE; ++OI)
+	e.varargs.push_back(lookup_or_add(*OI));
+    if (I->isCommutative()) {
+	// Ensure that commutative instructions that only differ by a permutation
+	// of their operands get the same value number by sorting the operand value
+	// numbers.  Since all commutative instructions have two operands it is more
+	// efficient to sort by hand rather than using, say, std::sort.
+	assert(I->getNumOperands() == 2 && "Unsupported commutative instruction!");
+	if (e.varargs[0] > e.varargs[1])
+	    std::swap(e.varargs[0], e.varargs[1]);
+    }
+
+    if (CmpInst *C = dyn_cast<CmpInst>(I)) {
+	// Sort the operand value numbers so x<y and y>x get the same value number.
+	CmpInst::Predicate Predicate = C->getPredicate();
+	if (e.varargs[0] > e.varargs[1]) {
+	    std::swap(e.varargs[0], e.varargs[1]);
+	    Predicate = CmpInst::getSwappedPredicate(Predicate);
+	}
+	e.opcode = (C->getOpcode() << 8) | Predicate;
+    } else if (InsertValueInst *E = dyn_cast<InsertValueInst>(I)) {
+	for (InsertValueInst::idx_iterator II = E->idx_begin(), IE = E->idx_end();
+	     II != IE; ++II)
+	    e.varargs.push_back(*II);
+    }
+
+    return e;
+}
+
+//===----------------------------------------------------------------------===//
+//                     ValueTable External Functions
+//===----------------------------------------------------------------------===//
+
+/// add - Insert a value into the table with a specified value number.
+void ValueTable::add(Value *V, uint32_t num) {
+    valueNumbering.insert(std::make_pair(V, num));
+}
+
+uint32_t ValueTable::lookup_or_add_call(CallInst *C) {
+    Function *F = C->getCalledFunction();
+    if (F != NULL && F->hasName() && F->getName().startswith(GLOBAL_FN_GLOBAL_ADDR)) {
+	Value *op = C->getOperand(0);
+	DenseMap<Value*, uint32_t>::const_iterator VI = valueNumbering.find(op);
+	if (VI != valueNumbering.end()) {
+	    return VI->second;
+	} else {
+	    // Not numbered yet
+	    return lookup_or_add(op);
+	}
+    } else {
+	valueNumbering[C] = nextValueNumber;
+	return nextValueNumber++;
+    }
+}
+
+/// lookup_or_add - Returns the value number for the specified value, assigning
+/// it a new number if it did not have one before.
+uint32_t ValueTable::lookup_or_add(Value *V) {
+    DenseMap<Value*, uint32_t>::iterator VI = valueNumbering.find(V);
+    if (VI != valueNumbering.end())
+	return VI->second;
+
+    if (!isa<Instruction>(V)) {
+//	errs () << *V << " => " << nextValueNumber << "\n";
+	valueNumbering[V] = nextValueNumber;
+	return nextValueNumber++;
+    }
+   
+    Instruction* I = cast<Instruction>(V);
+    Expression exp;
+    switch (I->getOpcode()) {
+    case Instruction::Call:
+	return lookup_or_add_call(cast<CallInst>(I));
+    case Instruction::Add:
+    case Instruction::FAdd:
+    case Instruction::Sub:
+    case Instruction::FSub:
+    case Instruction::Mul:
+    case Instruction::FMul:
+    case Instruction::UDiv:
+    case Instruction::SDiv:
+    case Instruction::FDiv:
+    case Instruction::URem:
+    case Instruction::SRem:
+    case Instruction::FRem:
+    case Instruction::Shl:
+    case Instruction::LShr:
+    case Instruction::AShr:
+    case Instruction::And:
+    case Instruction::Or:
+    case Instruction::Xor:
+    case Instruction::ICmp:
+    case Instruction::FCmp:
+    case Instruction::Trunc:
+    case Instruction::ZExt:
+    case Instruction::SExt:
+    case Instruction::FPToUI:
+    case Instruction::FPToSI:
+    case Instruction::UIToFP:
+    case Instruction::SIToFP:
+    case Instruction::FPTrunc:
+    case Instruction::FPExt:
+    case Instruction::PtrToInt:
+    case Instruction::IntToPtr:
+    case Instruction::BitCast:
+    case Instruction::Select:
+    case Instruction::ExtractElement:
+    case Instruction::InsertElement:
+    case Instruction::ShuffleVector:
+    case Instruction::InsertValue:
+    case Instruction::GetElementPtr:
+	exp = create_expression(I);
+	break;
+    case Instruction::ExtractValue:
+//	exp = create_extractvalue_expression(cast<ExtractValueInst>(I));
+//	break;
+    default:
+	valueNumbering[V] = nextValueNumber;
+	return nextValueNumber++;
+    }
+
+    uint32_t& e = expressionNumbering[exp];
+    if (!e) e = nextValueNumber++;
+    valueNumbering[V] = e;
+    return e;
+}
+
+/// lookup - Returns the value number of the specified value. Fails if
+/// the value has not yet been numbered.
+uint32_t ValueTable::lookup(Value *V) const {
+    DenseMap<Value*, uint32_t>::const_iterator VI = valueNumbering.find(V);
+    assert(VI != valueNumbering.end() && "Value not numbered?");
+    return VI->second;
+}
+
+/// clear - Remove all entries from the ValueTable.
+void ValueTable::clear() {
+    valueNumbering.clear();
+    expressionNumbering.clear();
+    nextValueNumber = 1;
+}
+
+/// erase - Remove a value from the value numbering.
+void ValueTable::erase(Value *V) {
+    valueNumbering.erase(V);
+}
+
+/// verifyRemoved - Verify that the value is removed from all internal data
+/// structures.
+void ValueTable::verifyRemoved(const Value *V) const {
+    for (DenseMap<Value*, uint32_t>::const_iterator
+	     I = valueNumbering.begin(), E = valueNumbering.end(); I != E; ++I) {
+	assert(I->first != V && "Inst still occurs in value numbering map!");
+    }
+}

--- a/ValueTable.h
+++ b/ValueTable.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//===----------------------------------------------------------------------===//
+// Chapel LLVM Locality Optimization by Akihiro Hayashi (ahayashi@rice.edu)
+//===----------------------------------------------------------------------===//
+// This is a reduced version of the original LLVM global value numbering pass. (GVN.cpp)
+// This pass is only used for assigning a value number to variables and expressions and 
+// does not perform any CSE (common subexpression elimination)
+//===----------------------------------------------------------------------===//
+
+#ifndef _VALUE_TABLE_H_
+#define _VALUE_TABLE_H_
+
+#include "llvm/IR/Value.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
+
+#include "llvmUtil.h"
+
+using namespace llvm;
+
+struct Expression {
+    uint32_t opcode;
+    Type *type;
+    SmallVector<uint32_t, 4> varargs;
+    
+    Expression(uint32_t o = ~2U) : opcode(o) { }
+    
+    bool operator==(const Expression &other) const {
+	if (opcode != other.opcode)
+	    return false;
+	if (opcode == ~0U || opcode == ~1U)
+	    return true;
+	if (type != other.type)
+	    return false;
+	if (varargs != other.varargs)
+	    return false;
+	return true;
+    }
+
+    // ignore type equality
+    bool equals(const Expression &other) const {
+	if (opcode != other.opcode)
+	    return false;
+	if (opcode == ~0U || opcode == ~1U)
+	    return true;
+	if (varargs != other.varargs)
+	    return false;
+	return true;
+    }
+    
+    friend hash_code hash_value(const Expression &Value) {
+	return hash_combine(Value.opcode, Value.type,
+			    hash_combine_range(Value.varargs.begin(),
+					       Value.varargs.end()));
+    }
+    
+    void dump() {
+	errs () << "Ope" << opcode << " ";
+	for (SmallVector<uint32_t, 4>::iterator I = varargs.begin(), E = varargs.end(); I != E; I++) {
+	    uint32_t val = *I;
+	    errs () << val << ", ";
+	}
+	errs () << "\n";
+    }
+};
+
+namespace llvm {
+    template <> struct DenseMapInfo<Expression> {
+	static inline Expression getEmptyKey() {
+	    return ~0U;
+	}
+
+	static inline Expression getTombstoneKey() {
+	    return ~1U;
+	}
+
+	static unsigned getHashValue(const Expression e) {
+	    using llvm::hash_value;
+	    return static_cast<unsigned>(hash_value(e));
+	}
+	static bool isEqual(const Expression &LHS, const Expression &RHS) {
+	    return LHS == RHS;
+	}
+    };
+
+}
+
+class ValueTable {
+    DenseMap<Value*, uint32_t> valueNumbering;
+    DenseMap<Expression, uint32_t> expressionNumbering;
+    uint32_t nextValueNumber;
+    
+    Expression create_expression(Instruction* I);
+    uint32_t lookup_or_add_call(CallInst* C);
+
+public:
+    ValueTable() : nextValueNumber(1) { }
+
+    uint32_t lookup_or_add(Value *V);
+    uint32_t lookup(Value *V) const;
+
+    Value* lookup_value(uint32_t id) { 
+	for (DenseMap<Value*, uint32_t>::const_iterator
+		 I = valueNumbering.begin(), E = valueNumbering.end(); I != E; ++I) {
+	    Value* val = I->first;
+	    uint32_t num = I->second;
+	    if (num == id) {
+		return val;
+	    }		
+	}
+	return NULL;
+    }
+
+    bool sameExpressions(Instruction *I1, Instruction *I2) {
+	Expression e1 = create_expression(I1);
+	Expression e2 = create_expression(I2);
+	if (e1.equals(e2)) {
+	    return true;
+	} else {
+	    return false;
+	}
+    }
+    
+    void add(Value *V, uint32_t num);
+    void clear();
+    void erase(Value *v);
+
+    uint32_t getNextUnusedValueNumber() { return nextValueNumber; }
+    void verifyRemoved(const Value *) const;
+
+    void dump() {
+	errs () << "[Value Table Dump Starts]\n";
+	for (DenseMap<Value*, uint32_t>::const_iterator
+		 I = valueNumbering.begin(), E = valueNumbering.end(); I != E; ++I) {
+	    Value* val = I->first;
+	    uint32_t num = I->second;
+	    errs () << num << " : " << *val << "\n";		
+	}
+	errs () << "[Value Table Dump Ends]\n";
+	errs () << "[Expresion Table Dump Starts]\n";
+	for (DenseMap<Expression, uint32_t>::const_iterator
+		 I = expressionNumbering.begin(), E = expressionNumbering.end(); I != E; ++I) {
+	    Expression val = I->first;
+	    uint32_t num = I->second;
+	    //errs () << num << " : Ope" << val.opcode << "\n";
+	    errs () << num << " : ";
+	    val.dump();
+	}
+	errs () << "[Expresion Table Dump Ends]\n";	   
+    }
+};
+#endif

--- a/llvmLocalityOptimization.cpp
+++ b/llvmLocalityOptimization.cpp
@@ -844,7 +844,7 @@ namespace {
 	    salvageChapelArrayAccess(F, VN, LocalArraysGVN, LocalArraysDecl);
 
 	    // Dump analysis results
-//	    if (debugThisFn[0] && F->getName() == debugThisFn) {
+	    if (debugThisFn[0] && F->getName() == debugThisFn) {
 		VN->dump();
 		// For Graphviz
 		G->dumpDOT();
@@ -852,7 +852,7 @@ namespace {
 		LocalArraysGVN->dump();
 		errs () << "[Local Array Decl]\n";
 		LocalArraysDecl->dump();
-//           }
+           }
 	    
 	    // Process each instruction
 	    // try to convert load/store/getelementptr with addrspace(100) to addrspace(0) with using IGraph
@@ -1003,6 +1003,20 @@ namespace {
   
 	
 	void salvageChapelArrayAccess(Function *F, ValueTable *VN, LocalArrayInfo *LocalArraysGVN, LocalArrayInfo *LocalArraysDecl) {
+	    /* Skip this if there is a branch instruction. */
+	    /* (TODO) Integrate salvageChapelArrayAccess into IGraph later*/
+	    for (inst_iterator IS = inst_begin(F), IE = inst_end(F); IS != IE; IS++) {
+		Instruction *targetInsn = &*IS;
+		TerminatorInst *branch = dyn_cast<TerminatorInst>(targetInsn);
+		if (branch) {
+		    ReturnInst *RI = dyn_cast<ReturnInst>(targetInsn);
+		    if (!RI) {
+			branch->dump();
+			return;
+		    }
+		}		
+	    }
+
 	    for (inst_iterator IS = inst_begin(F), IE = inst_end(F); IS != IE; IS++) {
 		Instruction *targetInsn = &*IS;
 		switch (targetInsn->getOpcode()) {

--- a/llvmLocalityOptimization.cpp
+++ b/llvmLocalityOptimization.cpp
@@ -116,7 +116,6 @@
 // For Debugging 
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/GraphWriter.h"
 
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
@@ -240,18 +239,6 @@ namespace {
 		File << *F;
 	    }
 	}
-
-	void dumpDOT(IGraph* G) {
-	    std::string Filename = "ig." + G->getName().str() + ".dot";
-	    std::error_code EC;
-	    raw_fd_ostream File(Filename.c_str(), EC, sys::fs::F_Text);
-
-	    if (EC) {
-		errs() << "Dump IGraph : error: "<< EC.message() << "\n";
-	    } else {
-		WriteGraph(File, (const IGraph*)G, false, "Habanero");
-	    }	    
-	}       
 #else
         void dumpFunction(Function *F, std::string mid) {
 	    std::string Filename = F->getName().str() + "." + mid + ".ll";
@@ -263,21 +250,6 @@ namespace {
 	    else
 		errs() << "  error opening file for writing!";
 	    errs() << "\n";
-	}
-
-	void dumpDOT(IGraph* G) {
-	    std::string Filename = "ig." + G->getName().str() + ".dot";
-	    errs() << "Writing '" << Filename << "'...";
-
-	    std::string ErrorInfo;
-	    raw_fd_ostream File(Filename.c_str(), ErrorInfo);
-
-	    if (ErrorInfo.empty())
-		WriteGraph(File, (const IGraph*)G, false, "Habanero");
-	    else
-		errs() << "  error opening file for writing!";
-	    errs() << "\n";
-
 	}
 #endif
 	// For Debugging purpose
@@ -897,7 +869,7 @@ namespace {
 	    if (debugThisFn[0] && F->getName() == debugThisFn) {
 		VN->dump();
 		// For Graphviz
-		dumpDOT(G);
+		G->dumpDOT();
 		errs () << "\n[Local Array GVN]\n";
 		LocalArraysGVN->dump();
 		errs () << "[Local Array Decl]\n";

--- a/llvmLocalityOptimization.cpp
+++ b/llvmLocalityOptimization.cpp
@@ -1227,7 +1227,7 @@ namespace {
 		if (debugPassInsn) {
 		    errs () << "Parent Insn : " << *node->getValue() <<"\n";
 		}
-		for (vector<Node*>::iterator I = node->parents_begin(), E = node->parents_end(); I != E; I++) {
+		for (Node::iterator I = node->parents_begin(), E = node->parents_end(); I != E; I++) {
 		    Node *tmp = *I;
 		    Value *v = tmp->getValue();
 		    if (debugPassInsn) {

--- a/llvmLocalityOptimization.cpp
+++ b/llvmLocalityOptimization.cpp
@@ -1,0 +1,1423 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//===----------------------------------------------------------------------===//
+// Chapel LLVM Locality Optimization by Akihiro Hayashi (ahayashi@rice.edu)
+//===----------------------------------------------------------------------===//
+// LLVM-based Locality Inference Pass (Locality Optimization Pass)
+// This pass tries to convert possibly-remote access (addrspace(100)* access)
+// to definitely-local to avoid runtime affinity checking overheads.
+//
+// To infer the locality, the locality optimization pass tries to utilize
+// following information :
+// - Case 1. Scalar access enclosed by Chapel's LOCAL statement.
+//   proc localizeByLocalStmt(ref x) : int {
+//     var p: int = 1;
+//     local { p = x; }
+//     return p + x; // x is definitely local
+//   }
+//   The locality level of x is inferred by searching SSA value graph,
+//   which is implemented in IGraph.[h|cpp].
+//   When you specify debugThisFn, the pass generates .dot file
+//   that can be visualized by the graphviz tool. (http://www.graphviz.org/)
+//
+// - Case 2. Array access enclosed by Chapel's LOCAL statement.
+//   proc habanero(A) : int {
+//     A(1) = 1; // A(1) is definitely local
+//     local { A(1) = 2; }
+//     A(2) = 3; // A(2) is possibly remote
+//   }
+//   This pass is element-sensitive. For example,
+//   the locality of A(1) is "definitely-local",
+//   but the pass leave A(2) "possibly-remote" since there is no enough
+//   information about the locality of A(2). 
+//   This is done by using a reduced version of the LLVM's global value numbering
+//   pass (in ValueTable.[h|cpp]) and a array offset analysis.
+//
+// - Case 3. locale locale array declaration
+//   proc localizeByArrayDecl () {
+//     var A: [1..10] int;
+//     return A(5);
+//    }
+//   The locality of A(5) is "definitely-local" since an array A is declared in this scope.
+//   Note that this pass is not element-sensitve so far. 
+//
+// Limitation, TODOs and future work:
+//   (Limitation) Locality Inference using SSA Value Graph with if statements:
+//     The current implementation does not propagate a condition even if a local statement is enclosed by if statement.
+//     Hence, we may fail to infer the locality in some cases.
+//     (e.g. if (condition) { local{ p = x } })
+//     
+//   (Limitation) Chapel's local statement detection:
+//     Currently, we are assuming that gf.addr function calls correspond to Chapel's local statements,
+//     but this is not always true because gf.addr is also used to extract a local pointer from a wide pointer.
+//     To avoid this problem, we have an std::vector named "NonLocals" to record a retun value of gf.addr
+//     which is also an argument of gf.make and the NonLocals are referred when doing "exemptionTest".
+//     This may not be always true. Ideally, a PGAS-LLVM frontend should tell the locality optimization pass
+//     which gf.addr call is a local statement.
+//
+//      Example :
+//        1. call i64* @.gf.addr.1(i64 addrspace(100)* %x)       // %x is definitely local
+//        2. %y = call i64* @.gf.addr.1(i64 addrspace(100)* %x)  // might not be definitely local
+//	     call i64 addrspace(100)* @.gf.make.1(..., %y) 
+//     
+//   (Limitation) Chapel's Array Declaration detection:
+//     We basically look for chpl__convertRuntimeTypeToValue to detect Chapel's array declaration.
+//     This pattern matching completely depends on how PGAS-LLVM frontend emits LLVM IR.
+//     Please see analyzeCallInsn for more details.
+//
+//   (Limitation) Intra-procedural pass:
+//     Unfortunately, the current implementation is not inter-procedural. 
+//
+//   (Future Work) The utilization of high-level information:
+//     The locality optimization pass has to recover high-level information such as 
+//     array accesses and local statements from low-level LLVM IR, but ideally,
+//     PGAS-LLVM frontend are supposed to add annotations to keep these information
+//     so the locality optimization can perform language-agnostic PGAS optimization.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvmLocalityOptimization.h"
+
+#ifdef HAVE_LLVM
+
+#define DEBUG_TYPE "locality-opt"
+
+#include "llvmUtil.h"
+#include <cstdio>
+#include <iostream>
+
+#if HAVE_LLVM_VER >= 35
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/CallSite.h"
+#include "llvm/IR/Verifier.h"
+#else
+#include "llvm/Support/InstIterator.h"
+#include "llvm/Support/CallSite.h"
+#include "llvm/Analysis/Verifier.h"
+#endif
+
+// For Debugging 
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/GraphWriter.h"
+
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+#include "llvm/Transforms/Utils/ValueMapper.h"
+#include "llvm/LinkAllPasses.h"
+
+#include "llvm/Transforms/Utils/Cloning.h"
+
+#include "llvmGlobalToWide.h"
+#include "IGraph.h"
+#include "ValueTable.h"
+
+using namespace llvm;
+
+namespace {
+
+    // For Debug
+    static bool debugPassInsn = true;
+    static const bool extraChecks = false;
+    static const char* debugThisFn = "";
+
+    // For Chapel Compiler & Breakdown
+    static const bool fLLVMDisableIG = false;
+    static const bool fLLVMDisableDecl = false;
+    static const bool fLLVMDisableGVN = false;
+    static const bool fLLVMLocalityOpt = true;
+
+    // Statistics
+    STATISTIC(NumLocalizedByIG, "Number of localized operations by IG");
+    STATISTIC(NumLocalizedByGVN, "Number of localized operations by GVN");
+    STATISTIC(NumLocalizedByArrayDecl, "Number of localized operations by Locale-local Array");
+        
+    struct LocalityOpt : public ModulePass {
+
+	static char ID;
+	
+	GlobalToWideInfo *info;
+	std::string layoutAfterwards;
+	
+	LocalityOpt(GlobalToWideInfo* _info, std::string layout) 
+	    : ModulePass(ID), info(_info), layoutAfterwards(layout) {	    
+	}
+	
+	// Constructor for running within opt, for testing and
+	// bugpoint.
+	LocalityOpt()
+	    : ModulePass(ID), info(NULL), layoutAfterwards("") {
+	}
+	
+	class LocalArrayEntry {
+	private:
+	    Value *op;
+	    bool whole;
+	    vector<unsigned int> localOffsets;
+	public:
+	    LocalArrayEntry(Value* _op, bool _whole) : op(_op), whole(_whole) {}
+	    void addLocalOffset(unsigned int offs) {
+		for (vector<unsigned int>::iterator I = localOffsets.begin(), E = localOffsets.end(); I != E; I++) {
+		    if (offs == *I) {
+			return;
+		    }
+		}
+		localOffsets.push_back(offs);
+	    }
+	    Value* getOp() { return op; }
+	    void dumpLocalOffsets() {
+		for (vector<unsigned int>::iterator I = localOffsets.begin(), E = localOffsets.end(); I != E; I++) {
+		    errs () << *I << ", ";
+		}
+		errs () << "\n";
+	    }
+	    bool isLocalOffset(int offset) {
+		if (std::find(localOffsets.begin(), localOffsets.end(), offset) != localOffsets.end()) {
+		    return true;
+		}
+		return false;
+	    }      	    
+	    bool isWholeLocal() { return whole; }
+	};
+
+	class LocalArrayInfo {
+	private:
+	    vector<LocalArrayEntry*> list;
+	public:
+	    LocalArrayInfo() {}
+	    void add(LocalArrayEntry *li) { list.push_back(li); }
+	    LocalArrayEntry* getEntryByValue(const Value *op) {
+		for (vector<LocalArrayEntry*>::iterator I = list.begin(), E = list.end(); I != E; I++) {
+		    LocalArrayEntry *li = *I;
+		    if (li->getOp() == op) {
+			return li;
+		    }
+		}
+		return NULL;
+	    }
+	    void dump() {
+		errs () << "[Local Array Info Start]\n";
+		for (vector<LocalArrayEntry*>::iterator I = list.begin(), E = list.end(); I != E; I++) {
+		    LocalArrayEntry *li = *I;
+		    errs () << *(li->getOp()) << "\n";
+		    errs () << "Definitely Local Offset : ";
+		    if (li->isWholeLocal()) {
+			errs () << "WHOLE\n";
+		    } else {
+			li->dumpLocalOffsets();
+		    }
+		}
+		errs () << "[Local Array Info End]\n";
+	    }
+	};
+
+#if HAVE_LLVM_VER >= 35
+	void dumpFunction(Function *F, std::string mid) {
+	    std::string Filename = F->getName().str() + "." + mid + ".ll";
+	    std::error_code EC;
+	    raw_fd_ostream File(Filename.c_str(), EC, sys::fs::F_Text);
+	    
+	    if (EC) {
+		errs() << "Dump Function : error: "<< EC.message() << "\n";		
+	    } else {
+		File << *F;
+	    }
+	}
+
+	void dumpDOT(IGraph* G) {
+	    std::string Filename = "ig." + G->getName().str() + ".dot";
+	    std::error_code EC;
+	    raw_fd_ostream File(Filename.c_str(), EC, sys::fs::F_Text);
+
+	    if (EC) {
+		errs() << "Dump IGraph : error: "<< EC.message() << "\n";
+	    } else {
+		WriteGraph(File, (const IGraph*)G, false, "Habanero");
+	    }	    
+	}       
+#else
+        void dumpFunction(Function *F, std::string mid) {
+	    std::string Filename = F->getName().str() + "." + mid + ".ll";
+	    std::string ErrorInfo;
+	    raw_fd_ostream File(Filename.c_str(), ErrorInfo);
+
+	    if (ErrorInfo.empty())
+		File << *F;
+	    else
+		errs() << "  error opening file for writing!";
+	    errs() << "\n";
+	}
+
+	void dumpDOT(IGraph* G) {
+	    std::string Filename = "ig." + G->getName().str() + ".dot";
+	    errs() << "Writing '" << Filename << "'...";
+
+	    std::string ErrorInfo;
+	    raw_fd_ostream File(Filename.c_str(), ErrorInfo);
+
+	    if (ErrorInfo.empty())
+		WriteGraph(File, (const IGraph*)G, false, "Habanero");
+	    else
+		errs() << "  error opening file for writing!";
+	    errs() << "\n";
+
+	}
+#endif
+	// For Debugging purpose
+	void insertPrintf(Module &M, Instruction *insertBefore, StringRef Str) {
+	    // Global Value
+	    Constant *StrConstant = ConstantDataArray::getString(M.getContext(), Str);
+	    GlobalVariable *GV = new GlobalVariable(M, StrConstant->getType(), true, GlobalValue::PrivateLinkage, StrConstant);
+	    GV->setUnnamedAddr(true);
+	    // GEP
+	    Value *zero = ConstantInt::get(Type::getInt32Ty(M.getContext()), 0);
+	    Value *gepArgs[] = { zero, zero };
+	    Instruction *gepInst = GetElementPtrInst::CreateInBounds(GV, gepArgs, "", insertBefore);
+	    // Printf
+	    Constant *putsFunc = M.getOrInsertFunction("puts", Type::getInt32Ty(M.getContext()), Type::getInt8PtrTy(M.getContext()), NULL);
+	    Value* printfArgs[1];
+	    printfArgs[0] = gepInst;
+	    CallInst::Create(putsFunc, printfArgs, "", insertBefore);
+	}
+
+	bool isaGlobalPointer(GlobalToWideInfo* info, Type* type) {
+	    PointerType* pt = dyn_cast<PointerType>(type);
+	    if( pt && pt->getAddressSpace() == info->globalSpace ) return true;
+	    return false;
+	}
+
+	IGraph* createIGraph(Module &M, Function *F) {
+	    IGraph *G = new IGraph(F->getName());
+	    for (Function::arg_iterator I = F->arg_begin(), 
+		     E = F->arg_end(); I!=E; ++I) {
+		Value *srcVal = I;
+		Node *srcNode = G->getNodeByValue(srcVal);
+		if (srcNode == NULL) {
+		    srcNode = new Node(srcVal);
+		    G->addNode(srcNode);
+		}
+		for (User *U : I->users()) {
+		    Value* dstVal = U;
+		    Node *dstNode = G->getNodeByValue(dstVal);
+		    if (dstNode == NULL) {
+			dstNode = new Node(dstVal);
+			G->addNode(dstNode);
+		    }
+		    srcNode->addChild(dstNode);
+		}
+	    }
+	    for (Function::iterator BI = F->begin(), BE = F->end(); BI != BE; BI++) {
+		BasicBlock* BB = BI;
+		for (BasicBlock::iterator I = BB->begin(), E = BB->end(); I != E; I++) {
+		    Instruction *insn = &*I;	
+		    Value *srcVal = insn;
+		    Node *srcNode = G->getNodeByValue(srcVal);
+		    if (srcNode == NULL) {
+			srcNode = new Node(srcVal);
+			G->addNode(srcNode);
+		    }
+		    for (User *U : I->users()) {
+			Value *dstVal = U;
+			Node *dstNode = G->getNodeByValue(dstVal);
+			if (dstNode == NULL) {
+			    dstNode = new Node(dstVal);
+			    G->addNode(dstNode);
+			}
+			srcNode->addChild(dstNode);
+		    }
+		}
+	    }
+	    return G;
+	}
+
+	void createValueTableInsn(ValueTable *vn, Instruction *insn) {
+	    if (insn->getType()->isVoidTy()) return;
+	    vn->lookup_or_add(insn);
+	}
+	
+	ValueTable* createValueTable(Function *F) {
+	    ValueTable *vn = new ValueTable();
+	    for (inst_iterator II = inst_begin(F), IE = inst_end(F); II != IE; ++II) {
+		Instruction *insn = &*II;
+		createValueTableInsn(vn, insn);
+	    }
+	    return vn;
+	}
+
+	bool isDefinitelyLocalAccordingToIG(Value* op, IGraph *G, std::vector<Value*> &NonLocals) {
+	    if (fLLVMDisableIG) {
+		return false;
+	    }
+	    bool definitelyLocal = false;
+	    bool exempt = false;
+	    int ll = info->globalSpace;
+	    // find smallest possible locality level
+	    for (vector<Node*>::iterator I = G->begin(), E = G->end(); I != E; I++) {
+		Node* n = *I;
+		int lltmp = n->getLL(op);
+		if (lltmp != -1 && lltmp < ll) {
+		    ll = lltmp;
+		}
+	    }
+	    exempt = exemptionTest(op, NonLocals);
+	    if (ll == 0 && !exempt) {
+		definitelyLocal = true;
+		NumLocalizedByIG++;
+		if (debugPassInsn) {
+		    errs () << *op << " is definitely local\n";
+		}
+	    } else if (ll == 0 && exempt) {
+		if (debugPassInsn) {
+		    errs () << *op << " is exempted\n";
+		}
+	    }
+	    return definitelyLocal;
+	}
+
+	// Assuming op is operand of GEP inst (e.g. getelementptr inbounds i64, i64 addrspace(100)* op)
+	// find array access and localize it if array descriptor is definitely local according to GVN info
+	bool isDefinitelyLocalAccordingToList(GetElementPtrInst* oldGEP, ValueToValueMapTy &VM, IGraph *G, LocalArrayInfo *LocalArrays, bool isGVN) {
+
+	    if (isGVN && fLLVMDisableGVN) {
+		return false;
+	    }
+	    if (!isGVN && fLLVMDisableDecl) {
+		return false;
+	    }
+
+	    Value *op = oldGEP->getPointerOperand();
+	    if (!op) {
+		return false;
+	    }
+	    LocalArrayEntry *local = LocalArrays->getEntryByValue(op);
+
+	    // First Step : See if this GEP access is array access. If so, see if a pointer to array is in LocalArrayInfo  
+	    bool possiblyLocal = false;
+	    bool definitelyLocal = false;
+	    int offset = -1;
+
+	    // Case 1 : this is GEP LocalArray, 0, 8 
+	    if (local) {		
+		possiblyLocal = true;
+	    }
+
+	    // Case 2 : this GEP is obaining a pointer to array element. (GEP %op, %offset)
+	    // Searching (GEP array, 0, 8) and see if array is in local LocalArray
+	    if (isa<LoadInst>(op)) {
+		LoadInst *loadInst = cast<LoadInst>(op);
+		GetElementPtrInst *gepInst = dyn_cast<GetElementPtrInst>(loadInst->getPointerOperand());
+		if (gepInst && gepInst->getNumIndices() == 2) {
+		    Constant *op1 = dyn_cast<Constant>(gepInst->getOperand(1));
+		    Constant *op2 = dyn_cast<Constant>(gepInst->getOperand(2));
+		    if (op1 != NULL && op2 != NULL
+			&& op1->getUniqueInteger() == 0 && op2->getUniqueInteger() == 8) {
+			// $shifteddata = GEP %arraydesciptor, 0 , 8
+			// original GEP is supposed to be array access (GEP %shifteddata, %offset)
+
+			// search array descriptor 
+			LocalArrayEntry *li1 = LocalArrays->getEntryByValue(gepInst);
+			if (li1) {
+			    possiblyLocal = true;
+			    local = li1;
+			}
+			
+			// search key assuming array descriptor has already been renamed.
+			const GetElementPtrInst *keyGep = NULL;
+			for (ValueToValueMapTy::iterator I = VM.begin(), E = VM.end(); I != E; I++) {
+			    if (I->second == gepInst) {
+				keyGep = cast<GetElementPtrInst>(I->first);
+				break;
+			    }
+			}
+			if (keyGep != NULL) {
+			    // this GEP is definitely array offset calculation
+			    const Value* v = keyGep->getPointerOperand();  
+			    LocalArrayEntry *li2 = LocalArrays->getEntryByValue(v);
+			    if (li2) {
+				possiblyLocal = true;
+				local = li2;
+			    }
+			}
+		    }
+		}	      
+	    }
+
+	    // putting it together
+	    if (possiblyLocal) {
+		if (!local || local->isWholeLocal()) {
+		    definitelyLocal = true;
+		} else {
+		    // Check if this offset is local
+		    offset = analyzeArrayAccessOffsets(oldGEP, G);
+		    if (!local || local->isLocalOffset(offset)) {
+			definitelyLocal = true;
+		    } else {
+			definitelyLocal = false;
+		    }
+		}
+	    } else {
+		definitelyLocal = false;
+	    }
+
+	    if (definitelyLocal) {
+		if (isGVN) {
+		    NumLocalizedByGVN++;
+		} else {
+		    NumLocalizedByArrayDecl++;
+		}
+	    }
+	    return definitelyLocal;
+	}
+	
+	Value* findNewOpOrInsertGF(Value *oldOp, ValueToValueMapTy &VM, Module &M, Instruction *insertBefore) {
+	    Value *tmpOp, *newOp;
+	    // check mapping
+	    ValueToValueMapTy::iterator I = VM.find(oldOp);
+	    if (I != VM.end() && I->second) {
+		tmpOp = I->second;
+	    } else {
+		tmpOp = oldOp;
+	    }
+	    Type* t = tmpOp->getType();
+	    if (t->isPointerTy() && t->getPointerAddressSpace() == info->globalSpace) {
+		// create gf.addr.
+		PointerType *addrType = cast<PointerType>(oldOp->getType());
+		assert(addrType != NULL);
+		if (addrType->getPointerElementType()->isPointerTy()) {
+		    newOp = tmpOp;
+		    if (debugPassInsn) {
+			errs() << "GF is not inserted\n";
+		    }
+		} else {
+		    Function* fn = getAddrFn(&M, info, addrType);
+		    Value* gf_addr_args[1];
+		    gf_addr_args[0] = tmpOp;
+		    newOp = CallInst::Create(fn, gf_addr_args, "", insertBefore);
+		    if (debugPassInsn) {
+			errs() << "GF Inserted : " << *newOp << "\n";
+		    }
+		}
+	    } else {
+		newOp = tmpOp;
+	    } 
+	    return newOp;
+	}
+
+	Instruction* duplicateCallInst(CallInst *oldCall, Function* newF) {
+	    Instruction *newCall;
+	    CallSite CS(oldCall);
+	    const AttributeSet &CallPAL = CS.getAttributes();
+	    SmallVector<Value*, 16> args;
+
+	    for (unsigned int i = 0; i < oldCall->getNumArgOperands(); i++) {
+		Value *op = oldCall->getArgOperand(i);
+		args.push_back(op);
+	    }
+	    
+	    if (InvokeInst *II = dyn_cast<InvokeInst>(oldCall)) {
+		newCall = InvokeInst::Create(newF, II->getNormalDest(), II->getUnwindDest(),
+					     args, "", oldCall);
+		cast<InvokeInst>(newCall)->setCallingConv(CS.getCallingConv());
+		cast<InvokeInst>(newCall)->setAttributes(CallPAL);
+	    } else {
+		newCall = CallInst::Create(newF, args, "", oldCall);
+		cast<CallInst>(newCall)->setCallingConv(CS.getCallingConv());
+		cast<CallInst>(newCall)->setAttributes(CallPAL);
+		if (cast<CallInst>(oldCall)->isTailCall())
+		    cast<CallInst>(newCall)->setTailCall();
+	    }
+	    if (MDNode *tbaa = oldCall->getMetadata(LLVMContext::MD_tbaa)) {
+		newCall->setMetadata(LLVMContext::MD_tbaa, tbaa);
+	    }
+	    if (MDNode *tbaaStruct = oldCall->getMetadata(LLVMContext::MD_tbaa_struct)) {
+		newCall->setMetadata(LLVMContext::MD_tbaa_struct, tbaaStruct);
+	    }
+	    return newCall;
+	}
+
+	bool checkNeedToWork(Instruction *insn, ValueToValueMapTy &VM) {
+	    bool needsWork = false;
+	    for(unsigned int i=0; i < insn->getNumOperands(); i++) {
+		Value *old = insn->getOperand(i);
+		ValueToValueMapTy::iterator I = VM.find(old);
+		if( I != VM.end() && I->second ) needsWork = true;
+	    }
+	    
+	    // check global
+	    if (insn->getOpcode() != Instruction::Call) {
+		for(unsigned int i=0; i < insn->getNumOperands(); i++) {
+		    Value *old = insn->getOperand(i);
+		    if( isaGlobalPointer(info, old->getType()) ) needsWork = true;
+		}
+		if( isaGlobalPointer(info, insn->getType()) ) needsWork = true;
+	    } else {
+		CallInst *call = cast<CallInst>(insn);
+		Function *F = call->getCalledFunction();
+		if (!F) return false;
+		if (isa<MemIntrinsic>(call) && isa<MemCpyInst>(call)) {
+		    Value* gDst = call->getArgOperand(0);
+		    Value* gSrc = call->getArgOperand(1);
+		    if (gDst->getType()->getPointerAddressSpace() == info->globalSpace
+			|| gSrc->getType()->getPointerAddressSpace() == info->globalSpace) {
+			needsWork = true;
+		    }			
+		} else if (F->getName().startswith(".gf.addr")) { 
+		    needsWork = true;
+		}
+	    }
+	    return needsWork;
+	}
+
+	void processInstruction(Instruction* targetInsn, SmallVector<Instruction*, 16> &deletedInsn, ValueToValueMapTy &VM, ValueTable *VN, Module &M, IGraph *G, LocalArrayInfo *LocalArraysGVN, LocalArrayInfo *LocalArraysDecl, std::vector<Value*> &NonLocals) {
+	    if(debugPassInsn) {
+		errs() << "@" << *targetInsn << "\n";
+	    }
+	    
+	    bool needsWork = checkNeedToWork(targetInsn, VM);
+	    if (!needsWork) {
+		if (debugPassInsn) { 
+		    errs() << "need not to work!\n"; 
+		}
+		return;
+	    }
+	    
+	    switch(targetInsn->getOpcode()) {
+	    case Instruction::PHI: { /* TODO : Consider PHI Node */ break; }
+	    case Instruction::BitCast: {
+		CastInst *oldCast = cast<CastInst>(targetInsn);
+		Value* op = oldCast->getOperand(0);
+		ValueToValueMapTy::iterator I = VM.find(op);
+		if (I != VM.end() && I->second) {
+		    Value* newOp = I->second;
+		    if (debugPassInsn) {
+			errs () << "Take a look :" << *newOp->getType() << "\n";
+		    }
+		    Type* oldSrcTy = oldCast->getSrcTy();
+		    Type* newSrcTy = newOp->getType();
+		    Type* oldDstTy = oldCast->getDestTy();
+		    assert(oldSrcTy->isPointerTy() && newSrcTy->isPointerTy() && oldDstTy->isPointerTy());
+		    bool srcIsWide = newSrcTy->getPointerAddressSpace() == 0;
+		    bool dstIsGlobal = oldDstTy->getPointerAddressSpace() == info->globalSpace;
+		    if (srcIsWide && dstIsGlobal) {
+			Type* newDstTy = convertTypeGlobalToWide(&M, info, oldDstTy);
+			Instruction* newInst = CastInst::Create(oldCast->getOpcode(), newOp, newDstTy, "", oldCast);
+			if (debugPassInsn) {
+			    errs() << "Old Instruction : " << *oldCast << "\n";
+			    errs() << "New Instruction : " << *newInst << "\n";
+			}
+			VM[oldCast] = newInst;
+			deletedInsn.push_back(oldCast);
+		    } else {
+			RemapInstruction(targetInsn, VM, RF_IgnoreMissingEntries);
+			if (debugPassInsn) {
+			    errs() << "New Instruction : " << *targetInsn << "\n";
+			}
+		    }
+		} else {
+		    if (debugPassInsn) {
+			errs () << "No transformation\n";
+		    }
+		}
+		break;
+	    }
+	    case Instruction::GetElementPtr: {
+		GetElementPtrInst *oldGEP = cast<GetElementPtrInst>(targetInsn);
+		if (oldGEP->getAddressSpace() == info->globalSpace) {
+		    Value *oldOp, *newOp;
+		    Instruction* newInst = NULL;
+		    // Old Operand addrspace(100)*
+		    oldOp = oldGEP->getPointerOperand();
+		    bool needToTransform = false;
+		    // For array access
+		    // Check if the pointer is definitely local (according to inequality graph)
+		    needToTransform |= isDefinitelyLocalAccordingToIG(oldOp, G, NonLocals);
+		    // Check if the pointer derives from locale-local array pointer (according to GVN)
+		    needToTransform |= isDefinitelyLocalAccordingToList(oldGEP, VM, G, LocalArraysGVN, true);
+		    // Check if the pointer derives from locale-local array pointer (according to locale-local array)
+		    needToTransform |= isDefinitelyLocalAccordingToList(oldGEP, VM, G, LocalArraysDecl, false);
+		    // 
+		    ValueToValueMapTy::iterator I = VM.find(oldOp);
+		    needToTransform |= (I != VM.end() && I->second);
+		    if (needToTransform) {
+			newOp = findNewOpOrInsertGF(oldOp, VM, M, oldGEP);
+			// creating new GEP
+			std::vector<Value *> args;
+			for (User::op_iterator OI = oldGEP->idx_begin(), OE = oldGEP->idx_end(); OI != OE; OI++) {
+			    args.push_back(*OI);
+			}
+			ArrayRef<Value*> argsRef(args);
+			// Create new GEP
+			bool inBounds = oldGEP->isInBounds();
+			if (inBounds) {
+			    newInst = GetElementPtrInst::CreateInBounds(newOp, argsRef, oldGEP->getName(), oldGEP);
+			} else {
+#if HAVE_LLVM_VER >= 35
+			    newInst = GetElementPtrInst::Create(newOp->getType(), newOp, argsRef, oldGEP->getName(), oldGEP);
+#else
+			    newInst = GetElementPtrInst::Create(newOp, argsRef, oldGEP->getName(), oldGEP);
+#endif			    
+			}			
+			if (debugPassInsn) {
+			    errs() << "Old Instruction : " << *oldGEP << "\n";
+			    errs() << "New Instruction : " << *newInst << "\n";
+			}
+			// TODO: reconsider return type of GEP
+			VM[oldGEP] = newInst;
+			deletedInsn.push_back(oldGEP);
+		    }
+		} else {
+		    RemapInstruction(oldGEP, VM, RF_IgnoreMissingEntries);
+		}
+		break;
+	    }
+	    case Instruction::Load: {
+		LoadInst *oldLoad = cast<LoadInst>(targetInsn);
+		RemapInstruction(oldLoad, VM, RF_IgnoreMissingEntries);
+		if(oldLoad->getPointerAddressSpace() == info->globalSpace) {
+		    Value *oldOp, *newOp;
+		    Instruction* newInst = NULL;
+		    // Old Operand addrspace(100)*
+		    oldOp = oldLoad->getPointerOperand();
+		    if (isDefinitelyLocalAccordingToIG(oldOp, G, NonLocals)) {
+			newOp = findNewOpOrInsertGF(oldOp, VM, M, oldLoad);
+			newInst = new LoadInst(newOp, 
+					       "", 
+					       oldLoad->isVolatile(), 
+					       oldLoad->getAlignment(),
+					       oldLoad->getOrdering(), 
+					       oldLoad->getSynchScope(), 
+					       oldLoad);
+			if (MDNode *tbaa = oldLoad->getMetadata(LLVMContext::MD_tbaa)) {
+			    newInst->setMetadata(LLVMContext::MD_tbaa, tbaa);
+			}
+			if (debugPassInsn) {
+			    errs() << "Old Instruction : " << *oldLoad << "\n";
+			    errs() << "New Instruction : " << *newInst << "\n";
+			}
+			if (!newInst->getType()->isPointerTy()) {
+			    oldLoad->replaceAllUsesWith(newInst);
+			}
+			VM[oldLoad] = newInst;
+			deletedInsn.push_back(oldLoad);
+		    }
+		}
+		break; 
+	    }
+	    case Instruction::Store: {
+		StoreInst *oldStore = cast<StoreInst>(targetInsn);
+		RemapInstruction(oldStore, VM, RF_IgnoreMissingEntries);
+		if (oldStore->getPointerAddressSpace() == info->globalSpace) {
+		    Value *oldOp, *newOp;
+		    Instruction* newInst = NULL;
+		    // Old Operand addrspace(100)*			
+		    oldOp = oldStore->getPointerOperand();
+		    if (isDefinitelyLocalAccordingToIG(oldOp, G, NonLocals)) {
+			newOp = findNewOpOrInsertGF(oldOp, VM, M, oldStore);
+			newInst = new StoreInst(oldStore->getValueOperand(), 
+						newOp, 
+						oldStore->isVolatile(), 
+						oldStore->getAlignment(), 
+						oldStore->getOrdering(), 
+						oldStore->getSynchScope(), 
+						oldStore);
+			if (MDNode *tbaa = oldStore->getMetadata(LLVMContext::MD_tbaa)) {
+			    newInst->setMetadata(LLVMContext::MD_tbaa, tbaa);
+			}
+			if (debugPassInsn) {
+			    errs() << "Old Instruction : " << *oldStore << "\n";
+			    errs() << "New Instruction : " << *newInst << "\n";
+			}
+			VM[oldStore] = newInst;
+			deletedInsn.push_back(oldStore);
+		    }
+		} 
+		break; 
+	    }
+	    case Instruction::Call: {
+		CallInst *oldCall = cast<CallInst>(targetInsn);
+		Function* oldF = oldCall->getCalledFunction(); // null if indirect
+		assert(oldF != NULL);
+		if (oldF->getName().startswith(".gf.addr")) {
+		    Value *op = oldCall->getArgOperand(0);
+		    ValueToValueMapTy::iterator I = VM.find(op);
+		    if (I != VM.end() && I->second) {
+			Value *addrOp = I->second;	
+			// TODO check
+			errs () << "Removing gf.addr : ";
+			op->getType()->dump(); 
+			errs () << " => ";
+			addrOp->getType()->dump();
+			errs () << "\n";
+			VM[oldCall] = addrOp;
+			deletedInsn.push_back(oldCall);
+			errs () << "gf.addr removed\n";
+		    }
+		    break;	    
+		} else if (isa<MemIntrinsic>(oldCall)) {
+		    if (isa<MemSetInst>(oldCall)) {
+			Value *oldDst = oldCall->getArgOperand(0);			
+			ValueToValueMapTy::iterator I = VM.find(oldDst);
+			if (I != VM.end() && I->second) {
+			    Value* newDst = I->second;
+			    CallSite CS(oldCall);
+			    const AttributeSet &CallPAL = CS.getAttributes();
+			    Type *types[2];
+			    Value *args[5];
+
+			    types[0] = newDst->getType();
+			    types[1] = oldCall->getArgOperand(2)->getType();
+
+			    args[0] = newDst;
+			    args[1] = oldCall->getArgOperand(1);
+			    args[2] = oldCall->getArgOperand(2);
+			    args[3] = oldCall->getArgOperand(3);
+			    args[4] = oldCall->getArgOperand(4);
+
+			    Function* memSetF = Intrinsic::getDeclaration(&M, Intrinsic::memset, types);
+			    Instruction* newCall = CallInst::Create(memSetF, args, "", oldCall);
+			    cast<CallInst>(newCall)->setCallingConv(CS.getCallingConv());
+			    cast<CallInst>(newCall)->setAttributes(CallPAL);
+			    if (cast<CallInst>(oldCall)->isTailCall()) {
+				cast<CallInst>(newCall)->setTailCall();
+			    }
+			    if (MDNode *tbaa = oldCall->getMetadata(LLVMContext::MD_tbaa)) {
+				newCall->setMetadata(LLVMContext::MD_tbaa, tbaa);
+			    }
+			    if (MDNode *tbaaStruct = oldCall->getMetadata(LLVMContext::MD_tbaa_struct)) {
+				newCall->setMetadata(LLVMContext::MD_tbaa_struct, tbaaStruct);
+			    }
+			    if (debugPassInsn) {
+				errs () << "MemSet Old Instruction : " << *oldCall << "\n";
+				errs () << "New Instruction : " << *newCall << "\n";
+			    }
+			    VM[oldCall] = newCall;
+			    deletedInsn.push_back(oldCall);			
+			} else {
+			    /* do nothing */
+			}
+			break;
+		    }
+		    assert(isa<MemCpyInst>(oldCall) || isa <MemMoveInst>(oldCall));
+		    Value *newDst, *newSrc;
+		    Value* oldDst = oldCall->getArgOperand(0);
+		    Value* oldSrc = oldCall->getArgOperand(1);
+		    bool needToTransform = false;
+
+		    unsigned dstSpace = oldDst->getType()->getPointerAddressSpace();
+		    unsigned srcSpace = oldSrc->getType()->getPointerAddressSpace();
+
+		    CallSite CS(oldCall);
+		    const AttributeSet &CallPAL = CS.getAttributes();
+		    Type *types[3];
+		    Value *args[5];
+		    
+		    if (srcSpace == info->globalSpace) {
+			ValueToValueMapTy::iterator I = VM.find(oldSrc);
+			bool renamed = I != VM.end() && I->second;
+			if (isDefinitelyLocalAccordingToIG(oldSrc, G, NonLocals) || renamed) {
+			    newSrc = findNewOpOrInsertGF(oldSrc, VM, M, oldCall);
+			    needToTransform = true;
+			}
+		    } else {
+			newSrc = oldSrc;
+		    }
+		    if (dstSpace == info->globalSpace) {
+			ValueToValueMapTy::iterator I = VM.find(oldDst);
+			bool renamed = I != VM.end() && I->second;
+			if (isDefinitelyLocalAccordingToIG(oldDst, G, NonLocals) || renamed) {
+			    newDst = findNewOpOrInsertGF(oldDst, VM, M, oldCall);
+			    needToTransform = true;
+			}
+		    } else {
+			newDst = oldDst;
+		    }
+
+		    if (!needToTransform) {
+			break;
+		    }
+
+		    types[0] = newDst->getType();
+		    types[1] = newSrc->getType();
+		    types[2] = oldCall->getArgOperand(2)->getType();
+
+		    args[0] = newDst;
+		    args[1] = newSrc;
+		    args[2] = oldCall->getArgOperand(2);
+		    args[3] = oldCall->getArgOperand(3);
+		    args[4] = oldCall->getArgOperand(4);
+
+		    Function* memF = NULL;
+		    if (isa<MemCpyInst>(oldCall)) {
+			memF = Intrinsic::getDeclaration(&M, Intrinsic::memcpy, types);
+		    } else if (isa <MemMoveInst>(oldCall)) {
+			memF = Intrinsic::getDeclaration(&M, Intrinsic::memmove, types);
+		    }
+		    Instruction* newCall = CallInst::Create(memF, args, "", oldCall);
+		    cast<CallInst>(newCall)->setCallingConv(CS.getCallingConv());
+		    cast<CallInst>(newCall)->setAttributes(CallPAL);
+		    if (cast<CallInst>(oldCall)->isTailCall()) {
+			cast<CallInst>(newCall)->setTailCall();
+		    }
+		    if (MDNode *tbaa = oldCall->getMetadata(LLVMContext::MD_tbaa)) {
+			newCall->setMetadata(LLVMContext::MD_tbaa, tbaa);
+		    }
+		    if (MDNode *tbaaStruct = oldCall->getMetadata(LLVMContext::MD_tbaa_struct)) {
+			newCall->setMetadata(LLVMContext::MD_tbaa_struct, tbaaStruct);
+		    }
+		    if (debugPassInsn) {
+			errs () << "Old Instruction : " << *oldCall << "\n";
+			errs () << "New Instruction : " << *newCall << "\n";
+		    }
+		    VM[oldCall] = newCall;
+		    deletedInsn.push_back(oldCall);		
+	
+		} else {
+		    RemapInstruction(targetInsn, VM, RF_IgnoreMissingEntries);
+		}
+		break;
+	    }
+	    default:
+		RemapInstruction(targetInsn, VM, RF_IgnoreMissingEntries);
+		if (debugPassInsn) {
+		    errs () << "New Instruction: " << *targetInsn << "\n";
+		}
+		break;
+	    }
+	}
+	
+	void localityOptimization(Module &M, Function* F) {
+	    // Don't do anything if there is no body.
+	    // Does nothing for special functions since they have no body.
+	    if( F->begin() == F->end() ) return;
+
+	    // TODO : invoke mem2reg pass to introduce SSA phi node	    
+	    
+	    // For Debug
+	    if (debugThisFn[0] && F->getName() == debugThisFn) {
+		// generate F->getName().before.ll 
+		dumpFunction(F, "before");
+		debugPassInsn = true;
+	    }
+	    
+	    // Allocate 
+	    LocalArrayInfo *LocalArraysGVN = new LocalArrayInfo();
+	    LocalArrayInfo *LocalArraysDecl = new LocalArrayInfo();
+	    static std::vector<Value*> NonLocals;
+	    
+	    // Create IGraph
+	    // Inspect all instructions and construt IGraph. Each node of IGraph contains a densemap that map that is one-to-one mapping of each operand into a specific address space (either 100 or 0).
+	    // If an instruction is enclosed by a local statement, set the locality level of each operand to 0.
+	    // Currently, we are assuming that gf.addr function calls correspond to Chapel's local statements, but this is not always true because gf.addr is also used to extract a local pointer from a wide pointer. We work on this later pass using NonLocals)       
+	    IGraph *G = createIGraph(M, F);
+
+	    // Perform a reduced version of GVN 
+	    ValueTable *VN = createValueTable(F);
+
+	    // Input  : VN, G
+	    // Output : LocalArraysGVN, LocalArrayDecl, NonLocals
+	    salvageChapelArrayAccess(F, VN, G, LocalArraysGVN, LocalArraysDecl, NonLocals);
+
+	    // Dump analysis results
+	    if (debugThisFn[0] && F->getName() == debugThisFn) {
+		VN->dump();
+		// For Graphviz
+		dumpDOT(G);
+		errs () << "\n[Local Array GVN]\n";
+		LocalArraysGVN->dump();
+		errs () << "[Local Array Decl]\n";
+		LocalArraysDecl->dump();
+		
+		// dump nonlocals	    
+		errs () << "[Non Locals]\n";
+		for (vector<Value*>::iterator I = NonLocals.begin(), E = NonLocals.end(); I != E; I++) {
+		    Value *tmp = *I;
+		    tmp->dump();
+		}
+	    }
+	    
+	    // Process each instruction
+	    // try to convert load/store/getelementptr with addrspace(100) to addrspace(0) with using IGraph
+	    SmallVector<Instruction*, 16> deletedInsn;
+	    ValueToValueMapTy ValueMap;
+	    for (inst_iterator II = inst_begin(F), IE = inst_end(F); II != IE; ++II) {
+		Instruction *insn = &*II;
+		processInstruction(insn, deletedInsn, ValueMap, VN, M, G, LocalArraysGVN, LocalArraysDecl, NonLocals);
+	    }
+	    for (unsigned int i = 0; i < deletedInsn.size(); i++) {
+		Instruction *insn = deletedInsn[i];
+		insn->removeFromParent();
+		insn->setName("");
+		insn->dropAllReferences();
+	    }
+
+	    // Cleanup
+	    // TODO delete
+	    ValueMap.clear();
+	    deletedInsn.clear();
+	    NonLocals.clear();
+
+	    // For Debug
+	    if (debugThisFn[0] && F->getName() == debugThisFn) {
+		// generate F->getName().before.ll 
+		dumpFunction(F, "after");
+	    }	
+	    
+            // TODO : invoke reg2mem pass 
+
+
+	}
+	
+	/*
+	  Locality Optimization Pass:
+	  
+	  This pass tries to replace address space 100 pointer with address space 0 pointer.
+	  1. Local Statement (by users)
+	  2. Locale local array declaration (by users but not explicitly expressed)
+	*/
+
+	virtual bool runOnModule(Module &M) {
+	    bool madeInfo = false;
+      
+	    // Normally we expect a user of this optimization to have
+	    // already produced an info object with the important
+	    // information, but if not we set some defaults here so
+	    // that tests can be created and bugpoint can be run.
+	    if( !info ) {
+		errs() << "Warning: GlobalToWide using default configuration\n";
+		info = new GlobalToWideInfo();
+		madeInfo = true;
+		info->globalSpace = 100;
+		info->wideSpace = 101;
+		info->localeIdType = M.getTypeByName("struct.c_localeid_t");
+		if( ! info->localeIdType ) {
+		    StructType* t = StructType::create(M.getContext(), "struct.c_localeid_t");
+		    t->setBody(Type::getInt32Ty(M.getContext()), Type::getInt32Ty(M.getContext()), NULL);
+		    info->localeIdType = t;
+		}
+		info->nodeIdType = Type::getInt32Ty(M.getContext());
+
+		// Now go identify special functions in the module by name.
+		for (Module::iterator next_func = M.begin(); next_func!= M.end(); )
+		{
+		    Function *F = &*next_func;
+		    ++next_func;
+
+		    FunctionType* FT = F->getFunctionType();
+
+		    // This may look like a crazy amount of checking, but we
+		    // need to do it in order to have bugpoint work with this
+		    // optimization, since it will basically try different ways
+		    // of corrupting the input.
+		    if( F->getName().startswith(GLOBAL_FN_GLOBAL_ADDR) &&
+			FT->getNumParams() == 1 &&
+			FT->getReturnType()->isPointerTy() &&
+			FT->getReturnType()->getPointerAddressSpace() == 0 &&
+			containsGlobalPointers(info, FT->getParamType(0)) ) {
+			Type* gType = FT->getParamType(0);
+			GlobalPointerInfo & r = info->gTypes[gType];
+			r.addrFn = F;
+			info->specialFunctions.insert(F);
+		    } else if( F->getName().startswith(GLOBAL_FN_GLOBAL_LOCID) &&
+			       FT->getNumParams() == 1 &&
+			       FT->getReturnType() == info->localeIdType &&
+			       containsGlobalPointers(info, FT->getParamType(0)) ) {
+			Type* gType = FT->getParamType(0);
+			GlobalPointerInfo & r = info->gTypes[gType];
+			r.locFn = F;
+			info->specialFunctions.insert(F);
+		    } else if( F->getName().startswith(GLOBAL_FN_GLOBAL_NODEID) &&
+			       FT->getNumParams() == 1 &&
+			       FT->getReturnType() == info->nodeIdType &&
+			       containsGlobalPointers(info, FT->getParamType(0)) ) {
+			Type* gType = FT->getParamType(0);
+			GlobalPointerInfo & r = info->gTypes[gType];
+			r.nodeFn = F;
+			info->specialFunctions.insert(F);
+		    } else if( F->getName().startswith(GLOBAL_FN_GLOBAL_MAKE) &&
+			       FT->getNumParams() == 2 &&
+			       FT->getParamType(0) == info->localeIdType &&
+			       FT->getParamType(1)->isPointerTy() &&
+			       FT->getParamType(1)->getPointerAddressSpace() == 0 &&
+			       containsGlobalPointers(info, FT->getReturnType()) ) {
+			Type* gType = FT->getReturnType();
+			GlobalPointerInfo & r = info->gTypes[gType];
+			r.makeFn = F;
+			info->specialFunctions.insert(F);
+		    } else if( F->getName().startswith(GLOBAL_FN_GLOBAL_TO_WIDE) &&
+			       FT->getNumParams() == 1 &&
+			       containsGlobalPointers(info, FT->getParamType(0)) ) {
+			Type* gType = FT->getParamType(0);
+			GlobalPointerInfo & r = info->gTypes[gType];
+			r.globalToWideFn = F;
+			info->specialFunctions.insert(F);
+		    } else if( F->getName().startswith(GLOBAL_FN_WIDE_TO_GLOBAL) &&
+			       FT->getNumParams() == 1 &&
+			       containsGlobalPointers(info, FT->getReturnType()) ) {
+			Type* gType = FT->getReturnType();
+			GlobalPointerInfo & r = info->gTypes[gType];
+			r.wideToGlobalFn = F;
+			info->specialFunctions.insert(F);
+		    }
+		}
+	    }
+
+	    assert(info->globalSpace > 0);
+	    assert(info->localeIdType);
+	    assert(info->nodeIdType);
+
+	    // Wide pointer address space must differ from the local one...
+	    assert(info->globalSpace != 0);
+	    assert(info->wideSpace != 0);
+	    assert(info->localeIdType != 0);
+	    assert(info->nodeIdType != 0);
+	    
+	    // Note : current implementation is not inter-procedural 
+	    for(Module::iterator func = M.begin(); func!= M.end(); func++) {
+		Function *F = &*func;
+		if (F->getName().startswith(".")) {
+		    continue; // skip special functions
+		}
+		localityOptimization(M, F);
+	    }
+
+	    // After it all, put the target info back.
+	    if( !madeInfo ) M.setDataLayout(layoutAfterwards);
+	    if( madeInfo ) delete info;
+	    
+	    return true;
+	}
+  
+	
+	void salvageChapelArrayAccess(Function *F, ValueTable *VN, IGraph *G, LocalArrayInfo *LocalArraysGVN, LocalArrayInfo *LocalArraysDecl, std::vector<Value*> &NonLocals) {
+	    for (inst_iterator IS = inst_begin(F), IE = inst_end(F); IS != IE; IS++) {
+		Instruction *targetInsn = &*IS;
+		switch (targetInsn->getOpcode()) {
+		case Instruction::Load:
+		case Instruction::Store:
+		{
+		    // search array access enclosed by local statement
+		    analyzeLoadStoreInsn(targetInsn, F, VN, G, LocalArraysGVN);
+		    break;
+		}
+		case Instruction::Call:
+		{
+		    // search array construction
+		    analyzeCallInsn(targetInsn, VN, G, LocalArraysDecl, NonLocals);
+		    break;
+		}
+		default:
+		    ; /* do nothing */		    
+		}		
+	    }
+	}
+
+	int analyzeArrayAccessOffsets(Instruction *getOffsetGEP, IGraph *G) {
+	    int ret = -1;
+	    if (getOffsetGEP) {
+		errs () << "Offset : \n";
+		errs () << *getOffsetGEP << "\n";
+		Instruction *offsetInsn = dyn_cast<Instruction>(getOffsetGEP->getOperand(1));
+		if (offsetInsn) {
+		    switch(offsetInsn->getOpcode()) {
+		    case Instruction::Load: {			
+			ret = 0;
+			break;
+		    }
+		    case Instruction::Shl: {
+			Constant *op1 = dyn_cast<Constant>(offsetInsn->getOperand(1));
+			if (op1) {
+			    ret = 1 << (int)(op1->getUniqueInteger().roundToDouble());
+			} else {
+			    ret = -1; 
+			}
+			break;
+		    }
+		    case Instruction::Mul: {
+			Constant *op1 = dyn_cast<Constant>(offsetInsn->getOperand(1));
+			if (op1) {
+			    ret = (int)(op1->getUniqueInteger().roundToDouble());
+			} else {
+			    ret = -1;
+			}						
+		    }
+		    }
+		}
+		
+	    }	    
+	    return ret;
+	}	    
+	
+	void analyzeLoadStoreInsn(Instruction *I, Function *F, ValueTable *VN, IGraph *G, LocalArrayInfo *LocalArrays) {
+	    if (isArrayAccessMemOp(I, G, info->globalSpace)) {
+                // for each store/load instruction that involves addrspace 100 and is supposed to be array access.
+		if (debugPassInsn) {
+		    errs () << *I << " is supposed to be array access\n";
+		}
+		GetElementPtrInst *gep1 = findGEP08FromMemOp(I, G);
+		if (gep1 == NULL) return;
+		for (inst_iterator IS2 = inst_begin(F), IE2 = inst_end(F); IS2 != IE2; IS2++) {
+		    Instruction *I2 = &*IS2;
+		    // search load/store instruction that is supposed to be local array access.
+		    if (I != I2 && isArrayAccessMemOp(I2, G, 0)) {
+			GetElementPtrInst *gep2 = findGEP08FromMemOp(I2, G);
+			if (gep2 == NULL) continue;
+			if (VN->sameExpressions(gep1, gep2)) {
+			    errs () << "[GVN worked!]\n";
+			    errs () << "\t Array Pointer :\n";
+			    errs () << "\t addrspace(100) : " << *gep1 << "\n";
+			    errs () << "\t addrspace(0)   : " << *gep2 << "\n";			    
+			    // mark  
+			    Value *localArray = gep1->getPointerOperand();
+			    LocalArrayEntry *li = LocalArrays->getEntryByValue(localArray);
+			    // Analyze Offset			    
+			    int offset = analyzeArrayAccessOffsets(dyn_cast<Instruction>(I2->getOperand(1)), G);
+			    if (offset != -1) {
+				//
+				if (!li) {
+				    li = new LocalArrayEntry(localArray, false);
+				    li->addLocalOffset(offset);
+				    LocalArrays->add(li);
+				} else {
+				    li->addLocalOffset(offset);
+				}
+			    }
+			}
+		    }
+		}
+	    }
+	}
+
+	void markNonLocalsRecursively(Value *v, std::vector<Value*> &visited, std::vector<Value*> &NonLocals) {
+	    bool notVisited = find(visited.begin(), visited.end(), v) == visited.end();
+	    if (isa<Instruction>(v) && notVisited) {
+		visited.push_back(v);
+		Instruction *insn = cast<Instruction>(v);
+		for (unsigned int i = 0; i < insn->getNumOperands(); i++) {
+		    Value *op = insn->getOperand(i);
+		    if (isa<CallInst>(op)) {
+			CallInst *callInsn2 = cast<CallInst>(op);
+			Function *calledFunc2 = callInsn2->getCalledFunction();
+			if (calledFunc2 && calledFunc2->getName().startswith(".gf.addr")) {
+			    Value *tmp = callInsn2->getArgOperand(0);
+			    NonLocals.push_back(tmp);
+			} 
+		    }
+		    markNonLocalsRecursively(op, visited, NonLocals);
+		}
+	    }
+	}
+
+	// check if construct_DefaultRectangularArr is in this function
+	void analyzeCallInsn(Instruction *I, ValueTable *VN, IGraph *G, LocalArrayInfo *LocalArrays, std::vector<Value*> &NonLocals) {
+	    if (isa<CallInst>(I)) {
+		CallInst *callInsn1 = cast<CallInst>(I);
+		Function *calledFunc1 = callInsn1->getCalledFunction();
+		// gf.make. 		
+		if (calledFunc1 == NULL) {
+		    return;
+		}
+		StringRef funcName = calledFunc1->getName();
+		if (funcName.startswith(".gf.make")) { 
+		    Value* v = callInsn1->getArgOperand(1);
+		    if (isa<CallInst>(v)) {
+			CallInst *callInsn2 = cast<CallInst>(v);
+			Function *calledFunc2 = callInsn2->getCalledFunction();
+			if (calledFunc2 && calledFunc2->getName().startswith("_construct_DefaultRectangularArr")) {
+			    LocalArrayEntry *li = new LocalArrayEntry(I, true);
+			    LocalArrays->add(li);
+			} else if (calledFunc2 && calledFunc2->getName().startswith(".gf.addr")) {
+			    NonLocals.push_back(v);
+			} 
+		    }
+		    std::vector<Value*> visited;
+		    markNonLocalsRecursively(v, visited, NonLocals);
+		} else if (funcName.startswith("chpl__convertRuntimeTypeToValue")) { //
+		    Value* v = callInsn1->getArgOperand(1);
+		    for (User *U : v->users()) {
+			Value *UI = U;
+			if (isa<LoadInst>(*UI)) {
+			    LoadInst *l = cast<LoadInst>(UI);
+			    if (l->getPointerOperand() == v) {
+				LocalArrayEntry *li = new LocalArrayEntry(UI, true);
+				LocalArrays->add(li);
+				// support chpl___ASSIGN
+				for (User *LU: l->users()) {
+				    Value *LUI = LU;
+				    if (isa<CallInst>(LUI)) {
+					CallInst *callInsn2 = cast<CallInst>(LUI);
+					Function *calledFunc2 = callInsn2->getCalledFunction();
+					if (calledFunc2 && calledFunc2->getName().startswith("chpl___ASSIGN_")
+					    && UI == callInsn2->getArgOperand(0)) {
+					    LocalArrayEntry *li2 = new LocalArrayEntry(LUI, true);
+					    LocalArrays->add(li2);
+					}
+				    }
+				}
+			    } 			    
+			}
+		    }
+		} else if (funcName.startswith("chpl__buildDomainExpr")) {
+		    Value* v = callInsn1->getOperand(1);		    
+		    for (User *U : v->users()) {
+			Value *UI = U;
+			if (isa<LoadInst>(UI)) {
+			    LoadInst *l = cast<LoadInst>(UI);
+			    if (l->getPointerOperand() == v) {
+				LocalArrayEntry *li = new LocalArrayEntry(UI, true);
+				LocalArrays->add(li);
+			    }
+			}
+		    }
+		}
+	    }    
+	}
+
+    	void searchGEP08Inst(vector<GetElementPtrInst*> &list, vector<Node*> &visited, Node *node) {
+	    vector<Node*>::iterator I = find(visited.begin(), visited.end(), node);
+	    if (I == visited.end()) {
+		visited.push_back(node);
+		if (debugPassInsn) {
+		    errs () << "Parent Insn : " << *node->getValue() <<"\n";
+		}
+		for (vector<Node*>::iterator I = node->parents_begin(), E = node->parents_end(); I != E; I++) {
+		    Node *tmp = *I;
+		    Value *v = tmp->getValue();
+		    if (debugPassInsn) {
+			errs () << "Parent Insn : " << *v <<"\n";
+		    }
+		    GetElementPtrInst *gepInst = dyn_cast<GetElementPtrInst>(v);
+		    if (gepInst && gepInst->getNumIndices() == 2) {
+			if (debugPassInsn) {
+			    errs () << "Candidate GEP : " << *gepInst << "\n";
+			}
+			Constant *op1 = dyn_cast<Constant>(gepInst->getOperand(1));
+			Constant *op2 = dyn_cast<Constant>(gepInst->getOperand(2));
+			if (op1 != NULL && op2 != NULL
+			    && op1->getUniqueInteger() == 0 && op2->getUniqueInteger() == 8) {
+			    vector<GetElementPtrInst*>::iterator I2 = find(list.begin(), list.end(), gepInst);
+			    if (I2 == list.end()) {
+				list.push_back(gepInst);
+			    }
+			} else {
+			    searchGEP08Inst(list, visited, tmp);
+			}
+		    } else {
+			searchGEP08Inst(list, visited, tmp);
+		    }
+		}
+	    }
+	}
+
+	GetElementPtrInst* findGEP08FromMemOp(Instruction *I, IGraph *G) {
+	    Value *op = NULL;
+	    if (isa<StoreInst>(I)) {
+		StoreInst* s = cast<StoreInst>(I);
+		op = s->getPointerOperand();
+	    } else if (isa<LoadInst>(I)) {
+		LoadInst* l = cast<LoadInst>(I);
+		op = l->getPointerOperand();
+	    } else {
+		return NULL;
+	    }
+	    if (!isa<Instruction>(op)) {
+		return NULL;
+	    }
+	    vector<GetElementPtrInst*> list;
+	    vector<Node*> visited;
+	    searchGEP08Inst(list, visited, G->getNodeByValue(op));
+	    if (list.size() == 0) {
+		return NULL;
+	    } else {
+		if (list.size() != 1) {
+		    errs () << "Warning : indirect access detected\n";
+		}
+		return list[0];
+	    }
+	}
+
+	bool isArrayAccessGEP(GetElementPtrInst* gep) {
+	    if (gep != NULL) {
+		Type* t = gep->getOperand(0)->getType();
+		if (t->isPointerTy()) {
+		    Type* t2 = t->getPointerElementType();
+		    if (isa<StructType>(t2)) {
+			if (t2->getStructName().startswith("chpl__class")) {
+			    return false;
+			}		    
+		    } else {
+			errs () << "not struct\n";
+		    }
+		}
+	    } else {
+		return false;
+	    }		
+	    return true;
+	}
+
+	bool isArrayAccessMemOp(Instruction *I, IGraph *G, unsigned addrSpace) {
+	    if (isa<StoreInst>(I)) {
+		StoreInst* s = cast<StoreInst>(I);
+		if (s->getPointerAddressSpace() != addrSpace) {
+		    return false;
+		}
+		GetElementPtrInst* gep = findGEP08FromMemOp(s, G);
+		return isArrayAccessGEP(gep);
+	    } else if (isa<LoadInst>(I)) {
+		LoadInst* l = cast<LoadInst>(I);
+		if (l->getPointerAddressSpace() != addrSpace) {
+		    return false;
+		}
+		errs () << "Load + 100 : " << *I << "\n";
+		GetElementPtrInst* gep = findGEP08FromMemOp(l, G);
+		return isArrayAccessGEP(gep);
+	    } else {
+		return false;
+	    }
+	}
+
+	bool exemptionTest(Value *op, std::vector<Value*> &NonLocals) {
+	    bool ret = false;
+	    // Case 1 : op = call @gf.make(%x, %y)
+	    //          = @gf.addr(op) <= assuming this stmt just unpacks local addr
+	    if (isa<CallInst>(op)) {		
+		CallInst *call = cast<CallInst>(op);
+		Function *F = call->getCalledFunction();
+		if (F && F->getName().startswith(".gf.make")) {
+		    ret = true;
+		}
+	    }
+	    // Case 2 : = @gf.make(%x, %y) 
+	    vector<Value*>::iterator I = find(NonLocals.begin(), NonLocals.end(), op);
+	    if (I != NonLocals.end()) {
+		ret = true;
+	    }
+	    return ret;
+	}
+
+    };
+}
+
+char LocalityOpt::ID = 0;
+static RegisterPass<LocalityOpt> X("locality-opt", "Locality Optimization Pass");
+
+ModulePass *createLocalityOpt(GlobalToWideInfo* info, std::string setlayout) {
+    return new LocalityOpt(info, setlayout);
+}
+#endif

--- a/llvmLocalityOptimization.cpp
+++ b/llvmLocalityOptimization.cpp
@@ -837,7 +837,9 @@ namespace {
 	    // Does nothing for special functions since they have no body.
 	    if( F->begin() == F->end() ) return;
 
-	    // TODO : invoke mem2reg pass to introduce SSA phi node	    
+	    legacy::FunctionPassManager* FPM_pre = new legacy::FunctionPassManager(&M);
+	    FPM_pre->add(llvm::createPromoteMemoryToRegisterPass());
+	    FPM_pre->run(*F);
 	    
 	    // For Debug
 	    if (debugThisFn[0] && F->getName() == debugThisFn) {
@@ -910,9 +912,9 @@ namespace {
 		dumpFunction(F, "after");
 	    }	
 	    
-            // TODO : invoke reg2mem pass 
-
-
+	    legacy::FunctionPassManager *FPM_post = new legacy::FunctionPassManager(&M);
+	    FPM_post->add(llvm::createDemoteRegisterToMemoryPass());
+	    FPM_post->run(*F);
 	}
 	
 	/*

--- a/llvmLocalityOptimization.cpp
+++ b/llvmLocalityOptimization.cpp
@@ -295,6 +295,7 @@ namespace {
 	    }
 	    IGraph::Answer answer = G->prove(op, insn, 0);
 	    if (answer == IGraph::TRUE) {
+		NumLocalizedByIG++;
 		return true;
 	    } else {
 		return false;
@@ -346,9 +347,7 @@ namespace {
 			if (li1) {
 			    possiblyLocal = true;
 			    local = li1;
-			    errs () << "HOGE2\n";
 			}
-			errs () << "HOGE\n";
 			// search key assuming array descriptor has already been renamed.
 			const GetElementPtrInst *keyGep = NULL;
 			for (ValueToValueMapTy::iterator I = VM.begin(), E = VM.end(); I != E; I++) {
@@ -818,10 +817,6 @@ namespace {
 	    // Don't do anything if there is no body.
 	    // Does nothing for special functions since they have no body.
 	    if( F->begin() == F->end() ) return;
-
-	    legacy::FunctionPassManager* FPM_pre = new legacy::FunctionPassManager(&M);
-	    FPM_pre->add(llvm::createPromoteMemoryToRegisterPass());
-	    FPM_pre->run(*F);
 	    
 	    // For Debug
 	    if (debugThisFn[0] && F->getName() == debugThisFn) {
@@ -884,11 +879,7 @@ namespace {
 		// generate F->getName().before.ll 
 		dumpFunction(F, "after");
 	    }	
-	    
-	    legacy::FunctionPassManager *FPM_post = new legacy::FunctionPassManager(&M);
-	    FPM_post->add(llvm::createDemoteRegisterToMemoryPass());
-	    FPM_post->run(*F);
-	}
+    	}
 	
 	/*
 	  Locality Optimization Pass:

--- a/llvmLocalityOptimization.h
+++ b/llvmLocalityOptimization.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2004-2015 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//===----------------------------------------------------------------------===//
+// Chapel LLVM Locality Optimization by Akihiro Hayashi (ahayashi@rice.edu)
+//===----------------------------------------------------------------------===//
+
+#ifndef _LLVMLOCALITYOPT_H_
+#define _LLVMLOCALITYOPT_H_
+
+#ifdef HAVE_LLVM
+
+#include "llvmUtil.h"
+
+class GlobalToWideInfo;
+llvm::ModulePass *createLocalityOpt(GlobalToWideInfo* info, std::string layout);
+
+#endif
+
+#endif

--- a/test/local.ll
+++ b/test/local.ll
@@ -1,0 +1,133 @@
+; RUN: opt --load %bindir/lib/llvm-pgas${MOD_EXT} -locality-opt -S < %s | FileCheck %s
+
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:64:64:64"
+
+; for Chapel Array
+%atomicflag = type { i8 }
+%atomic_int64 = type { i64 }
+%chpl_object_object = type { i32, i32 }
+%range_int64_t_bounded_F = type { %rangeBase_int64_t_bounded_F, i8 }
+%rangeBase_int64_t_bounded_F = type { i64, i64, i64, i64 }
+%chpl_DefaultDist_object = type { %chpl_BaseDist_object }
+%chpl_BaseDist_object = type { %chpl_object_object, %atomic_int64, %list_BaseDom, %atomicflag }
+%list_BaseDom = type { %chpl_listNode_BaseDom_object addrspace(100)*, %chpl_listNode_BaseDom_object addrspace(100)*, i64 }
+%chpl_listNode_BaseDom_object = type { %chpl_object_object, %chpl_BaseDom_object addrspace(100)*, %chpl_listNode_BaseDom_object addrspace(100)* }
+%chpl_BaseDom_object = type { %chpl_object_object, %atomic_int64, %list_BaseArr, %atomicflag }
+%chpl_DefaultRectangularDom_1_int64_t_F_object = type { %chpl_BaseRectangularDom_object, %chpl_DefaultDist_object addrspace(100)*, [1 x %range_int64_t_bounded_F] }
+%chpl_BaseRectangularDom_object = type { %chpl_BaseDom_object }
+%chpl_BaseArr_object = type { %chpl_object_object, %atomic_int64, %chpl_BaseArr_object addrspace(100)* }
+%chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object = type { %chpl_BaseArr_object, %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)*, [1 x i64], [1 x i64], [1 x i64], i64, i64, i64 addrspace(100)*, i64 addrspace(100)*, i8 }
+%chpl___RuntimeTypeInfo8 = type { %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)* }
+%list_BaseArr = type { %chpl_listNode_BaseArr_object addrspace(100)*, %chpl_listNode_BaseArr_object addrspace(100)*, i64 }
+%chpl_listNode_BaseArr_object = type { %chpl_object_object, %chpl_BaseArr_object addrspace(100)*, %chpl_listNode_BaseArr_object addrspace(100)* }
+
+declare void @chpl__buildDomainExpr(%range_int64_t_bounded_F %_e0_ranges.val, %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** nocapture %_retArg, i64 %_ln, i8* %_fn)
+declare void @chpl__ensureDomainExpr3(%range_int64_t_bounded_F* %_e0_x, %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** %_retArg, i64 %_ln, i8* %_fn)
+declare %chpl___RuntimeTypeInfo8 @chpl__buildArrayRuntimeType6(%chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** %dom, i64 %_ln, i8* %_fn)
+declare void @chpl__convertRuntimeTypeToValue8(%chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** %dom, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)** %_retArg, i64 %_ln, i8* %_fn)
+declare void @_build_range(i64 %low, i64 %high2, %range_int64_t_bounded_F* %_retArg, i64 %_ln, i8* %_fn)
+declare i64* @.gf.addr.1(i64 addrspace(100)*) readnone
+declare %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object* @.gf.addr.2(%chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)*) readnone
+
+; proc localizeByLocalStmt(ref x) : int {
+;    var p: int = 1;
+;    local { p = x; }
+;    return p + x;
+; }
+
+define i64 @localizeByLocalStmt(i64 addrspace(100)* %x) {
+; CHECK: @localizeByLocalStmt(
+; )
+entry:
+  %0 = call i64* @.gf.addr.1(i64 addrspace(100)* %x)
+  %1 = load i64, i64* %0
+; CHECK: call i64* @.gf.addr.
+; CHECK; load i64, i64*
+; CHECK: add i64
+; CHECK: ret i64
+  %2 = load i64, i64 addrspace(100)* %x
+  %3 = add i64 %2, %1
+  ret i64 %3
+}
+
+; proc localizeByArrayDecl () {
+;  var A: [1..10] int;
+;  return A(5);
+; }
+
+define internal i64 @localizeByArrayDecl() {
+; CHECK: @localizeByArrayDecl(
+; )
+entry:
+  %type_tmp = alloca %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)*
+  store %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)* null, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)** %type_tmp
+  %call_tmp = alloca %range_int64_t_bounded_F
+  %call_tmp2 = alloca %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)*
+  store %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)* null, %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** %call_tmp2
+  %_runtime_type_tmp_ = alloca %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)*
+  %_fn = alloca i8
+  store %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)* null, %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** %_runtime_type_tmp_
+  call void @_build_range(i64 1, i64 10, %range_int64_t_bounded_F* %call_tmp, i64 9, i8* %_fn)
+  call void @chpl__ensureDomainExpr3(%range_int64_t_bounded_F* %call_tmp, %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** %call_tmp2, i64 9, i8* %_fn)
+  %0 = call %chpl___RuntimeTypeInfo8 @chpl__buildArrayRuntimeType6(%chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** %call_tmp2, i64 9, i8* %_fn)
+  %.fca.0.extract = extractvalue %chpl___RuntimeTypeInfo8 %0, 0
+  store %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)* %.fca.0.extract, %chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** %_runtime_type_tmp_
+  call void @chpl__convertRuntimeTypeToValue8(%chpl_DefaultRectangularDom_1_int64_t_F_object addrspace(100)** %_runtime_type_tmp_, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)** %type_tmp, i64 9, i8* %_fn)
+  %1 = load %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)*, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)** %type_tmp
+; CHECK: call %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object* @.gf.addr
+; CHECK: getelementptr inbounds %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object*
+  %2 = getelementptr inbounds %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)* %1, i32 0, i32 3
+; CHECK: getelementptr inbounds [1 x i64], [1 x i64]*  
+  %3 = getelementptr inbounds [1 x i64], [1 x i64] addrspace(100)* %2, i64 0, i64 0
+; CHECK: load i64, i64*
+  %4 = load i64, i64 addrspace(100)* %3
+  %5 = mul i64 5, %4
+; CHECK: getelementptr inbounds %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object*  
+  %6 = getelementptr inbounds %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object,  %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)* %1, i32 0, i32 8
+; CHECK: load i64 addrspace(100)*, i64 addrspace(100)**
+  %7 = load i64 addrspace(100)*, i64 addrspace(100)* addrspace(100)* %6
+; CHECK: call i64* @.gf.addr.
+; CHECK: getelementptr inbounds i64, i64*
+  %8 = getelementptr inbounds i64, i64 addrspace(100)* %7, i64 %5
+; CHECK: load i64, i64*
+  %9 = load i64, i64 addrspace(100)* %8
+; CHECK: ret i64  
+  ret i64 %9
+}
+
+; proc localizeByGVN(A) : int {
+;    A(1) = 1; // local
+;    local { A(1) = 2; }
+;    A(2) = 3; // non-local
+; }
+
+define internal fastcc void @localizeByGVN(%chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)* %A.val) #1 {
+; CHECK: @localizeByGVN(
+; )
+entry:
+; CHECK: call %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object* @.gf.addr.
+; CHECK: getelementptr inbounds %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object*
+  %0 = getelementptr inbounds %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)* %A.val, i64 0, i32 3, i64 0
+; CHECK: load i64, i64*  
+  %1 = load i64, i64 addrspace(100)* %0
+; CHECK: call %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object* @.gf.addr.  
+  %2 = getelementptr inbounds %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)* %A.val, i64 0, i32 8
+; CHECK: load i64 addrspace(100)*, i64 addrspace(100)**
+  %3 = load i64 addrspace(100)*, i64 addrspace(100)* addrspace(100)* %2  
+  %4 = getelementptr inbounds i64, i64 addrspace(100)* %3, i64 %1
+; CHECK: store i64 1, i64*
+  store i64 1, i64 addrspace(100)* %4
+  %5 = tail call %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object* @.gf.addr.2(%chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object addrspace(100)* %A.val)
+  %6 = getelementptr inbounds %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object* %5, i64 0, i32 3, i64 0
+  %7 = load i64, i64* %6
+  %8 = getelementptr inbounds %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object, %chpl_DefaultRectangularArr_int64_t_1_int64_t_F_object* %5, i64 0, i32 8
+  %9 = load i64 addrspace(100)*, i64 addrspace(100)** %8
+  %10 = tail call i64* @.gf.addr.1(i64 addrspace(100)* %9)
+  %11 = getelementptr inbounds i64, i64* %10, i64 %7
+  store i64 2, i64* %11
+  %12 = load i64, i64 addrspace(100)* %0
+  %13 = shl i64 %12, 1
+  %14 = getelementptr inbounds i64, i64 addrspace(100)* %3, i64 %13
+  store i64 3, i64 addrspace(100)* %14
+  ret void
+}


### PR DESCRIPTION
# Summary

An initial version of LLVM-based Locality Inference Pass (Locality Optimization Pass). This pass tries to convert _possibly-remote accesses_ (addrspace(100)\* accesses) to _definitely-local accesses_ as much as possible at compilation time to avoid runtime affinity checking overheads.
# What I would expect

I would appreciate if Chapel folks give me some feedback particularly on:
- Detection of Chapel Runtime API calls
  
  The current implementation tries to recover _Local statement_,  _Chapel Array Construction_, and _Chapel Array Access_ since such information is lost at the time of LLVM IR generation. Additionally, the recovery process can easily fail because it completely depends on how the Chapel-LLVM frontends emits LLVM IRs. I'd suggest that the frontend add some annotations and/or attributes so the LLVM-based PGAS optimization can easily recognize the high-level information. Also this will be helpful to make this pass language-agnostic.
- Coding style
  
  If there is a preferred coding style for this repository. Please let me know.

Any other feedback is certainly appreciated! For more details of the locality optimization pass, please see below.
# How it works

To infer the locality, the locality optimization pass tries to utilize following information :
(Please also see test/local.ll)
### Case 1. Scalar access enclosed by Chapel's LOCAL statement

```
 proc localizeByLocalStmt(ref x) : int {
     var p: int = 1;
     local { p = x; }
     return p + x; // x is definitely local
  }
```

The locality level of x is inferred by searching an SSA value graph, which is implemented in IGraph.[h|cpp]. When you specify debugThisFn, the pass generates .dot file that can be visualized by the graphviz tool. (http://www.graphviz.org/)
### Case 2. Array access enclosed by Chapel's LOCAL statement

```
proc habanero(A) : int {
    A(1) = 1; // A(1) is definitely local
    local { A(1) = 2; }
    A(2) = 3; // A(2) is possibly remote
}
```

The locality optimization pass is element-sensitive. For example, the locality of A(1) is _definitely-local_, but the pass leave A(2) _possibly-remote_ since there is no enough information about the locality of A(2). This is done by using a reduced version of the LLVM's global value numbering pass for assigning a value number to variables and expressions (in ValueTable.[h|cpp]) and an array offset analysis.
### Case 3. Locale-locale array declaration

```
proc localizeByArrayDecl () {
    var A: [1..10] int;
    return A(5);
}
```

The locality of A(5) is _definitely-local_ since an array A is declared in this scope. Note that this pass is not element-sensitve so far. 
# Limitations
### Chapel's Local statement Detection

Currently, we are assuming that gf.addr function calls correspond to Chapel's local statements, but this is not always true because gf.addr is also used to extract a local pointer from a wide pointer. To avoid this problem, we have an std::vector named "NonLocals" to record a retun value of gf.addr which is also an argument of gf.make and the NonLocals are referred when doing "exemptionTest". This may not be always true. Ideally, a PGAS-LLVM frontend should tell the locality optimization pass which gf.addr call is a local statement.

Example :

```
call i64* @.gf.addr.1(i64 addrspace(100)* %x)       // %x is definitely local
```

```
%y = call i64* @.gf.addr.1(i64 addrspace(100)* %x)  // might not be definitely local
call i64 addrspace(100)* @.gf.make.1(..., %y)
```
### Chapel's Array Declaration Detection

We basically look for chpl__convertRuntimeTypeToValue to detect Chapel's array declaration. Please see analyzeCallInsn for more details.
# TODOs and future work
### The utilization of high-level information

The locality optimization pass has to recover high-level information such as array accesses and local statements from low-level LLVM IR, but ideally, PGAS-LLVM frontend are supposed to add annotations to keep these information so the locality optimization can easily recognize high-level information and perform language-agnostic PGAS optimization.
### Locality  Inference considering if statements

The current implementation does not propagate a condition even if a local statement is enclosed by if statement. Hence, we may fail to infer the locality in some cases like this:
`
if (condition) { local{ p = x } })
`
### Make it inter-procedural pass

This can make more _possibly-remote accesses_ to _definitely-local accesses_.
### More experiments with the latest version of the Chapel compiler (1.12.0)

I have been mainly working with the Chapel compiler 1.9.0. I need to check more if the locality optimization pass works.
